### PR TITLE
added download and uploading for files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ node_modules
 # Optional REPL history
 .node_repl_history
 
+
+aws.json

--- a/example-run.js
+++ b/example-run.js
@@ -4,7 +4,8 @@ var Falafel = require('./');
 
 // Start the server
 var apptalk = new Falafel().wrap({
-	directory: __dirname+'/example'
+	directory: __dirname+'/example',
+	aws: require('./aws.json')
 });
 
 exports.apptalk = apptalk;
@@ -34,34 +35,34 @@ var util = require('util');
 
 
 // REQUEST: Sample body, base 64 encoded
-apptalk([{
-  "id": "123-def",
-  "header": {
-    "message": "webhook_request"
-  },
-  "body": {
-		"input": {
-    	"access_token": "50349efe7fc91a5566b3f4ccc5a4c815ac98e400"
-		},
-		"http": {
-			"headers": {
-				"Content-Type": ["application/json"]
-				// "Content-Type": ["application/x-www-form-urlencoded"]
-			},
-			"body": {
-				"id":123,
-				"name":"Chris Houghton"
-			},
-			// "body": "Zm9vW2Jhcl09YmF6",
-			"form": []
-		}
-  }
-}], {}, function (err, result) {
-
-	console.log('error', err);
-	console.log(util.inspect(result, false, null));
-
-});
+// apptalk([{
+//   "id": "123-def",
+//   "header": {
+//     "message": "webhook_request"
+//   },
+//   "body": {
+// 		"input": {
+//     	"access_token": "50349efe7fc91a5566b3f4ccc5a4c815ac98e400"
+// 		},
+// 		"http": {
+// 			"headers": {
+// 				"Content-Type": ["application/json"]
+// 				// "Content-Type": ["application/x-www-form-urlencoded"]
+// 			},
+// 			"body": {
+// 				"id":123,
+// 				"name":"Chris Houghton"
+// 			},
+// 			// "body": "Zm9vW2Jhcl09YmF6",
+// 			"form": []
+// 		}
+//   }
+// }], {}, function (err, result) {
+//
+// 	console.log('error', err);
+// 	console.log(util.inspect(result, false, null));
+//
+// });
 
 
 // RESPONSE: Sample workflow data

--- a/example/connectors/pipedrive/download_file/model.js
+++ b/example/connectors/pipedrive/download_file/model.js
@@ -1,0 +1,20 @@
+module.exports = {
+
+	method: 'get',
+
+	url: '{{url}}',
+
+	afterSuccess: function (body, params) {
+		return when.promise(function (resolve, reject) {
+
+			falafel.files.upload({
+				name: params.file_name,
+				contents: new Buffer(body)
+			})
+
+			.done(resolve, reject)
+
+		});
+	}
+
+}

--- a/example/connectors/pipedrive/upload_file/model.js
+++ b/example/connectors/pipedrive/upload_file/model.js
@@ -6,17 +6,18 @@ module.exports = function (params) {
 
     falafel.files.download(params.file)
 
-    .then(function (result) {
+    .done(function (result) {
       console.log(result);
       fs.writeFileSync('/Users/chrishoughton/Desktop/'+result.name, result.contents);
-    })
-
-    .done(function () {
-      resolve({
-        success: true,
-        message: 'You\'d normally show an API response here.'
-      });
+      resolve(result);
     }, reject);
+    //
+    // .done(function () {
+    //   resolve({
+    //     success: true,
+    //     message: 'You\'d normally show an API response here.'
+    //   });
+    // }, reject);
 
   });
 }

--- a/example/connectors/pipedrive/upload_file/model.js
+++ b/example/connectors/pipedrive/upload_file/model.js
@@ -1,0 +1,22 @@
+var fs = require('fs');
+
+
+module.exports = function (params) {
+  return when.promise(function (resolve, reject) {
+
+    falafel.files.download(params.file)
+
+    .then(function (result) {
+      console.log(result);
+      fs.writeFileSync('/Users/chrishoughton/Desktop/'+result.name, result.contents);
+    })
+
+    .done(function () {
+      resolve({
+        success: true,
+        message: 'You\'d normally show an API response here.'
+      });
+    }, reject);
+
+  });
+}

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -54,14 +54,15 @@ module.exports = function (options) {
             } else if (res.statusCode !== 200) {
               reject(new Error(res.statusCode));
             } else {
-              var fifteenMinutes = new Date(Date.now() + 15 * 60000);
-              var signedUrl = client.signedUrl(fileName, fifteenMinutes);
+              var twentyFourHours = new Date(Date.now() + 24 * 60 * 60000);
+              var signedUrl = client.signedUrl(fileName, twentyFourHours);
 
               // Resolve with an object following the "file" schema
               resolve({
                 name: params.name,
                 url: signedUrl,
-                mime_type: mimeType
+                mime_type: mimeType,
+                expires: Math.round(twentyFourHours.getTime() / 1000)
               });
             }
           });
@@ -98,10 +99,14 @@ module.exports = function (options) {
 
           // Resolve with
           resolve({
+            // The contents that was downloaded
             contents: body,
+
+            // Pass back what was passed in to be helpful
             name: file.name,
-            mime_type: file.mime_type
-          })
+            mime_type: file.mime_type,
+            expires: file.expires
+          });
         }
       });
 

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -1,0 +1,117 @@
+var knox   = require('knox');
+var when   = require('when');
+var guid   = require('mout/random/guid');
+var util   = require('util');
+var needle = require('needle');
+var mmm    = require('mmmagic');
+
+
+module.exports = function (options) {
+
+  if (!_.isObject(options.aws)) {
+    return;
+  }
+
+  /*
+  * Upload a file to S3.
+  */
+  var upload = function (params) {
+    return when.promise(function (resolve, reject) {
+
+      var client = knox.createClient({
+        key: options.aws.key,
+        secret: options.aws.secret,
+        bucket: 'workflow-file-uploads',
+        region: 'us-west-2'
+      });
+
+
+      // Generate a random file name
+      var fileName = guid();
+      var buffer;
+      if (!util.isBuffer(params.contents)) {
+        return when.reject(new Error('Please pass the `contents` as a Node.js Buffer.'))
+      } else {
+        buffer = params.contents;
+      }
+
+      // Detect the file type
+      var magic = new mmm.Magic(mmm.MAGIC_MIME_TYPE);
+      magic.detect(buffer, function (err, mimeType) {
+        if (err) {
+          reject(err);
+        } else {
+
+          // TODO: should we pass the content-type to S3?
+          var headers = {
+            'Content-Type': mimeType
+          };
+
+          // Stick the buffer in S4
+          client.putBuffer(buffer, fileName, headers, function (err, res) {
+            if (err) {
+              reject(err);
+            } else if (res.statusCode !== 200) {
+              reject(new Error(res.statusCode));
+            } else {
+              var fifteenMinutes = new Date(Date.now() + 15 * 60000);
+              var signedUrl = client.signedUrl(fileName, fifteenMinutes);
+
+              // Resolve with an object following the "file" schema
+              resolve({
+                name: params.name,
+                url: signedUrl,
+                mime_type: mimeType
+              });
+            }
+          });
+
+        }
+      });
+
+    });
+  };
+
+
+  /*
+  * Download a file from S3. The object passed here should have been one that
+  * was returned via the `upload` function above in a previous workflow step.
+  */
+  var download = function (file) {
+    return when.promise(function (resolve, reject) {
+
+      needle.get(file.url, {
+        parse: false,
+        open_timeout: 0,
+        read_timeout: 0
+      }, function (err, res, body) {
+        if (err) {
+          reject(err);
+        } else if (res.statusCode !== 200) {
+          reject(new Error(res.statusCode));
+        } else {
+
+          // Ensure downloaded data is a buffer
+          if (!util.isBuffer(body)) {
+            body = new Buffer(body);
+          }
+
+          // Resolve with
+          resolve({
+            contents: body,
+            name: file.name,
+            mime_type: file.mime_type
+          })
+        }
+      });
+
+    });
+  };
+
+
+  falafel.files = {
+    upload: upload,
+    download: download
+  };
+
+};

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -47,7 +47,7 @@ module.exports = function (options) {
             'Content-Type': mimeType
           };
 
-          // Stick the buffer in S4
+          // Stick the buffer in S3
           client.putBuffer(buffer, fileName, headers, function (err, res) {
             if (err) {
               reject(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,9 @@ var Falafel = function () {
 				buildConnectorsJson(options.directory, connectorsConfig);
 			}
 
+			// Add in the file upload & download stuff
+			require('./fileHandler')(options);
+
 			// Bind the connectors and return the handler
 			var apptalk =  bindConnectors(connectorsConfig, options);
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "license": "ISC",
   "dependencies": {
     "@trayio/threadneedle": "^1.0.17",
+    "knox": "^0.9.2",
     "lodash": "^4.1.0",
+    "mmmagic": "^0.4.4",
     "mout": "^0.11.1",
     "qs": "^6.2.0",
     "requireindex": "^1.1.0",


### PR DESCRIPTION
This PR has my suggested code for handling files in Falafel. It's not the finished product, but I think it's fair that this version should be "production ready", incorporating backwards compatible changes moving forwards.

Key components:

### 1. Add an `aws.json` file in every connector

This should be under `.gitignore`, and have 

```json
{
  "key": "special-workflow-file-user-key",
  "secret": "special-workflow-file-user-secret"
}
```

### 2. Add a `files` utility to falafel

There are now two new functions:

#### `falafel.files.upload`

Uploads a file to S3 (after being downloaded from a third party API)

```js
falafel.files.upload({
  name: 'my-file-name.pdf', // name of the file for passing around the workflow
  contents: new Buffer(body) // the body should be passed as a node.js buffer if it hasn't already
})

.done(function (result) {
/* 
  {
    "name": "my-file-name.pdf",
    "url": "https://workflow-file-uploads.s3-us-west-2.amazonaws.com/07d425f2-675b-44e8-bb48-16243078228f?Expires=1469523705&AWSAccessKeyId=AKIAICOSMQGZTMV7CYBQ&Signature=E1uon3VDYJJzoA7Iuy2iqQutNZA%3D",
    "mime_type": "application/pdf"
  };
*/
});
```

The `url` is a signed URL that is valid for 15 minutes, and can be passed around the workflow. (Note that this is not ideal for longer running workflows)

The `name` is simple the inputted file name. 

The `mime_type` is a best effort guess from falafel at what type of file it is. Uses [mmmagic](https://github.com/mscdex/mmmagic).


#### `falafel.files.download`

Downloads a file from S3 (before being sent to an API).

Designed to take the exact output of the upload function above. Downloads the file from the signed URL, returning an object with a `contents` Node.js buffer:

```js
falafel.files.download({
  "name": "my-file-name.pdf",
  "url": "https://workflow-file-uploads.s3-us-west-2.amazonaws.com/07d425f2-675b-44e8-bb48-16243078228f?Expires=1469523705&AWSAccessKeyId=AKIAICOSMQGZTMV7CYBQ&Signature=E1uon3VDYJJzoA7Iuy2iqQutNZA%3D",
  "mime_type": "application/pdf"
})

.done(function (result) {
/*
{ 
  contents: <Buffer 2f 2a 0a 20 2a 20 54 68 65 20 54 79 70 65 6b 69 74 20 73 65 72 76 69 63 65 20 75 73 65 64 20 74 6f 20 64 65 6c 69 76 65 72 20 74 68 69 73 20 66 6f 6e ... >,
  name: 'ohx0hfv.js',
  mime_type: 'text/plain' 
}
*/
});
``` 

It's entirely up to connector as to how these utilities are used, but the suggested approach is:

* Create a `my_file` parameter in the schema.js, of type object. 
* Pass the `file` object (returned from the original upload) around the workflow, directly to this `my_file` parameter 


### Things not being handled

* Deleting of files (should we do this / or add a TTL?)
* Anything to do with file sizes (should we have a max size?)



