### PR TITLE
F/request reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ This can be declared like so:
 module.exports = {
 
   // Filter function to determine whether the request should result
-  // in a workflow being triggered.
+  // in a workflow being triggered. If you want to pass all http requests
+  // to the connector then just return true here.
   filter: function (params, http) {
     return (http.method === 'POST');
   },
@@ -288,7 +289,22 @@ module.exports = {
     return {
       data: http.body
     };
+  },
+
+  // If you'd like to respond to the HTTP message from the third party because
+  // they're expecting a response (Salesforce notification), then also add a reply
+  // method here, passing a `http` object.
+  reply: function (params, http, output) {
+    return {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml'
+      },
+      body: '<myxml>test</myxml>'
+    }
   }
+
+
 
 };
 ```

--- a/example/connectors/pipedrive/webhook/request.js
+++ b/example/connectors/pipedrive/webhook/request.js
@@ -64,6 +64,16 @@ module.exports = {
     //   api_key: params.api_key
     // });
 
+  },
+
+  reply: function (input, http, output) {
+    return {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml'
+      },
+      body: '<myxml>test</myxml>'
+    }
   }
 
 };

--- a/lib/bindConnectors/bindMessage.js
+++ b/lib/bindConnectors/bindMessage.js
@@ -38,7 +38,11 @@ module.exports = function (message, threadneedle, connectorConfig) {
 
 			// Otherwise run the method
 			else {
-				threadneedle[methodName](event.body).done(resolve, reject);
+				threadneedle[methodName](event.body).done(function (result) {
+          resolve({
+            body: result
+          });
+        }, reject);
 			}
 
 		});

--- a/lib/bindConnectors/bindTriggerRequest.js
+++ b/lib/bindConnectors/bindTriggerRequest.js
@@ -30,6 +30,10 @@ module.exports = function (message, options) {
           return http.body;
         };
 
+        var reply = message.request.reply || function () {
+          return; // undefined is ok
+        };
+
         // Determine if we should trigger the workflow
         var shouldTrigger = filter(event.body.input, event.body.http);
 
@@ -49,7 +53,15 @@ module.exports = function (message, options) {
           // If something new has been returned, use that. Otherwise
           // use the original body (which may have been tweaked via reference)
           .then(function (tweaked) {
-            return (tweaked || event.body.http.body);
+            var output = (tweaked || event.body.http.body);
+
+            return {
+              version: 2,
+              body: {
+                output: output,
+                http: reply(event.body.input, event.body.http, output)
+              }
+            };
           })
 
           .done(resolve, reject);

--- a/lib/bindConnectors/bindTriggerResponse.js
+++ b/lib/bindConnectors/bindTriggerResponse.js
@@ -13,7 +13,14 @@ module.exports = function (message) {
     event.body.http = parseRequestBody(event.body.http);
 
     // Run and ensure it's a promise
-    return when(message.response(event.input, event.body.http, event.body.reply || {}));
+    return when.promise(function (resolve, reject) {
+      var response = message.response(event.input, event.body.http, event.body.reply || {});
+      when(response).done(function (result) {
+        resolve({
+          body:result
+        });
+      }, reject);
+    });
 
   };
 };

--- a/lib/bindConnectors/formatMessage.js
+++ b/lib/bindConnectors/formatMessage.js
@@ -4,11 +4,15 @@
 * in the cluster service format.
 */
 var _ = require('lodash');
+var endsWith = require('mout/string/endsWith');
 
-module.exports = function (event, response) {
+module.exports = function (event, response, version) {
+
+  // var isRequest = endsWith(event.header.message, '_request');
 
   return {
     id: event.id,
+    version: (version === 2) ? 2 : undefined, // only declare on v2
     header: {},
     body: response
   };

--- a/lib/bindConnectors/formatMessage.js
+++ b/lib/bindConnectors/formatMessage.js
@@ -4,11 +4,8 @@
 * in the cluster service format.
 */
 var _ = require('lodash');
-var endsWith = require('mout/string/endsWith');
 
 module.exports = function (event, response, version) {
-
-  // var isRequest = endsWith(event.header.message, '_request');
 
   return {
     id: event.id,

--- a/lib/bindConnectors/index.js
+++ b/lib/bindConnectors/index.js
@@ -99,7 +99,7 @@ module.exports = function (config, options) {
 
 					// Run the API call, and respond with the appropriate stuff
 					messageHooks[event.header.message](event).done(function (response) {
-						resolve(formatMessage(event, response));
+						resolve(formatMessage(event, response.body, response.version));
 					}, function (err) {
 						resolve(formatError(err, event));
 					});

--- a/test/bindConnectors/formatMessage.js
+++ b/test/bindConnectors/formatMessage.js
@@ -1,0 +1,55 @@
+var assert      = require('assert');
+var _ 	        = require('lodash');
+var formatMessage = require('../../lib/bindConnectors/formatMessage');
+
+
+
+describe('#formatMessage', function () {
+
+  it('should format a regular message correctly, not setting version', function () {
+    var input = {
+      event: {
+        id: '123-456',
+      },
+      response: {
+        testing: true
+      },
+      version: 1
+    };
+
+    var expected = {
+      id: '123-456',
+      header: {},
+      body: {
+        testing: true
+      },
+      version: undefined
+    };
+
+    assert.deepEqual(formatMessage(input.event, input.response, input.version), expected)
+  });
+
+  it('should handle set version 2 when explicitly defined', function () {
+    var input = {
+      event: {
+        id: '123-456',
+      },
+      response: {
+        testing: true
+      },
+      version: 2
+    };
+
+    var expected = {
+      id: '123-456',
+      header: {},
+      body: {
+        testing: true
+      },
+      version: 2
+    };
+
+    assert.deepEqual(formatMessage(input.event, input.response, input.version), expected)
+  });
+
+});


### PR DESCRIPTION
Key changes:

* `bindMessage`, `bindTriggerRequest`, `bindTriggerResponse` now return an object with a `body` and `version` parameter, rather than simply returning the body
* The new response from these methods goes into the `formatMessage` - which sets the `version` if it is 2
* Added a sync `reply` method which can return a HTTP object that will be passed to the `http` body  parameter 
* Updated readme