### PR TITLE
Globals false bug fix

### DIFF
--- a/example-run.js
+++ b/example-run.js
@@ -4,7 +4,7 @@ var Falafel = require('./');
 
 // Start the server
 var apptalk = new Falafel().wrap({
-	directory: __dirname+'/example',
+	directory: __dirname+'/exampleTwo',
 	//aws: require('./aws.json')
 });
 

--- a/example-run.js
+++ b/example-run.js
@@ -4,7 +4,7 @@ var Falafel = require('./');
 
 // Start the server
 var apptalk = new Falafel().wrap({
-	directory: __dirname+'/exampleTwo',
+	directory: __dirname+'/example',
 	//aws: require('./aws.json')
 });
 

--- a/exampleTwo/connectors/testconnector/test_op/schema.js
+++ b/exampleTwo/connectors/testconnector/test_op/schema.js
@@ -3,6 +3,8 @@ module.exports = {
 
   title: 'Test operation',
 
+  globals: false,
+
   input: {
 
 		basic_auth: {

--- a/lib/bindConnectors/getMissingParams.js
+++ b/lib/bindConnectors/getMissingParams.js
@@ -18,8 +18,9 @@ module.exports = function (params, messageSchema, globalSchema) {
     });
   }
 
-  // ... and from the global schema
-  if (globalSchema) {
+  // ... and from the global schema unless explicitly excluded
+  var includeGlobals = ( _.isUndefined(messageSchema.globals) ? true : messageSchema.globals );
+  if (includeGlobals && globalSchema) {
     _.each(globalSchema.input || {}, function (obj, key) {
       if (obj.required === true) {
         requiredKeys.push(key);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/test/bindConnectors/bindMessage.js
+++ b/test/bindConnectors/bindMessage.js
@@ -61,8 +61,7 @@ describe('#bindMessage', function () {
 			on: function () {},
 			hasRequiredParams: function (keys) {
 				requiredKeys = keys;
-			}
-		}, {
+			},
 			globalSchema: {
 				input: {
 					access_token: {

--- a/test/bindConnectors/getMissingParams.js
+++ b/test/bindConnectors/getMissingParams.js
@@ -1,0 +1,156 @@
+var assert      = require('assert');
+var _ 	        = require('lodash');
+var getMissingParams = require('../../lib/bindConnectors/getMissingParams');
+
+
+describe('#getMissingParams', function () {
+
+	it('should pass - empty array', function () {
+
+		var missingParams = getMissingParams(
+			{
+				test1: 'test1',
+				test2: 123,
+				test3: [{}],
+				test4: {
+					test4Sub: 'test4Sub'
+				}
+			},
+			{
+
+				input: {
+					test2: {
+						type: 'number',
+						required: true
+					},
+					test3: {
+						type: 'array'
+					},
+					test4: {
+						type: 'object',
+						properties: {
+							test4Sub: {
+								type: 'string'
+							}
+						}
+					}
+				}
+
+			},
+			{
+
+				input: {
+					test1: {
+						type: 'string',
+						required: true
+					}
+				}
+
+			}
+
+		);
+
+		assert(missingParams);
+
+	});
+
+	it('should fail - array has "test1"', function () {
+
+		var missingParams = getMissingParams(
+			{
+				test2: 123,
+				test3: [{}],
+				test4: {
+					test4Sub: 'test4Sub'
+				}
+			},
+			{
+
+				input: {
+					test2: {
+						type: 'number',
+						required: true
+					},
+					test3: {
+						type: 'array'
+					},
+					test4: {
+						type: 'object',
+						properties: {
+							test4Sub: {
+								type: 'string'
+							}
+						}
+					}
+				}
+
+			},
+			{
+
+				input: {
+					test1: {
+						type: 'string',
+						required: true
+					}
+				}
+
+			}
+
+		);
+
+		assert.equal(missingParams[0], 'test1');
+
+	});
+
+	it('should pass, ignoring globals', function () {
+
+		var missingParams = getMissingParams(
+			{
+				test2: 123,
+				test3: [{}],
+				test4: {
+					test4Sub: 'test4Sub'
+				}
+			},
+			{
+				globals: false,
+
+				input: {
+					test2: {
+						type: 'number',
+						required: true
+					},
+					test3: {
+						type: 'array'
+					},
+					test4: {
+						type: 'object',
+						properties: {
+							test4Sub: {
+								type: 'string'
+							}
+						}
+					}
+				}
+
+			},
+			{
+
+				input: {
+					test1: {
+						type: 'string',
+						required: true
+					}
+				}
+
+			}
+
+		);
+
+		assert.notEqual(missingParams[0], 'test1');
+
+	});
+
+
+
+});


### PR DESCRIPTION
When running/executing an operation, `globals: false` is taken into account when checking required parameters.