### PR TITLE
auto generate docs table for parameters

### DIFF
--- a/example-run.js
+++ b/example-run.js
@@ -4,7 +4,7 @@ var Falafel = require('./');
 
 // Start the server
 var apptalk = new Falafel().wrap({
-	directory: __dirname+'/exampleTwo',
+	directory: __dirname+'/example',
 	//aws: require('./aws.json')
 });
 

--- a/example/connectors.json
+++ b/example/connectors.json
@@ -11,7 +11,8 @@
     "version": "2.0",
     "tags": [
       "service",
-      "crm"
+      "crm",
+      "trigger"
     ],
     "icon": {
       "type": "url",

--- a/example/connectors/pipedrive/connector.js
+++ b/example/connectors/pipedrive/connector.js
@@ -19,7 +19,7 @@ module.exports = {
   version: '2.0',
 
   // Tags attached to the connector
-  tags: ['service', 'crm'],
+  tags: ['service', 'crm', 'trigger'],
 
   // Icon of the connector.
   icon: {

--- a/example/docs.html
+++ b/example/docs.html
@@ -1,0 +1,55 @@
+
+
+<h2>Configuration</h2>
+<table class="table-striped">
+	<tbody>
+		<tr>
+			<th style="width: 25%">
+				Operation
+			</th>
+			<th>
+				Description
+			</th>
+		</tr>
+
+		
+	</tbody>
+</table>
+
+
+
+<h2>Trigger Configuration</h2>
+<table class="table-striped">
+	<tbody>
+		<tr>
+			<th style="width: 25%">
+				Operation
+			</th>
+			<th>
+				Description
+			</th>
+		</tr>
+
+		
+		<tr>
+			<td>
+				<em>List people</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
+		<tr>
+			<td>
+				<em>Webhook</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
+	</tbody>
+</table>
+
+

--- a/exampleTwo/connectors.json
+++ b/exampleTwo/connectors.json
@@ -15,6 +15,7 @@
       {
         "name": "test_date_formatter",
         "title": "Test date formatter",
+        "description": "Auto formats dates.",
         "input_schema": {
           "type": "object",
           "properties": {

--- a/exampleTwo/connectors/testconnector/test_date_formatter/schema.js
+++ b/exampleTwo/connectors/testconnector/test_date_formatter/schema.js
@@ -1,6 +1,10 @@
 
 module.exports = {
 
+  title: 'Test date formatter',
+
+  description: 'Auto formats dates.',
+
   input: {
 
     date: {

--- a/exampleTwo/docs.html
+++ b/exampleTwo/docs.html
@@ -1,0 +1,46 @@
+
+
+<h2>Configuration</h2>
+<table class="table-striped">
+	<tbody>
+		<tr>
+			<th style="width: 25%">
+				Operation
+			</th>
+			<th>
+				Description
+			</th>
+		</tr>
+
+		
+		<tr>
+			<td>
+				<em>Test date formatter</em>
+			</td>
+			<td>
+				Auto formats dates.
+			</td>
+		</tr>
+		
+		<tr>
+			<td>
+				<em>Test operation</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
+		<tr>
+			<td>
+				<em>Test operation</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
+	</tbody>
+</table>
+
+

--- a/lib/docsGenerator/index.js
+++ b/lib/docsGenerator/index.js
@@ -1,0 +1,30 @@
+/*
+* Generate docs table for the Helpscout docs page. All this does it take all 
+* of the operations, and creates an HTML table in the `docs.html` file.
+*/
+
+module.exports = function (directory) {
+
+	var fs = require('fs');
+
+	// Show the trigger afterwards
+	var connectorsJson = _.sortBy(require(directory+'/connectors.json'), function (connector) {
+		if ((connector.tags || []).indexOf('trigger') !== -1) {
+			return 0;
+		} else {
+			return -1;
+		}
+	});
+
+	// Build the HTML, using the template.ejs
+	var templateFile   = fs.readFileSync(__dirname+'/template.ejs').toString();
+	var compiled = _.template(templateFile);
+	var html = compiled({
+		connectors: connectorsJson
+	});
+
+	// Write to the `docs.html` file in the connector root (next to connectors.json)
+	fs.writeFileSync(directory+'/docs.html', html);
+
+};
+

--- a/lib/docsGenerator/template.ejs
+++ b/lib/docsGenerator/template.ejs
@@ -1,0 +1,28 @@
+<% _.each(connectors, function (connector) { %>
+
+<h2><% if ((connector.tags || []).indexOf('trigger') !== -1) { %>Trigger Configuration<% } else { %>Configuration<% } %></h2>
+<table class="table-striped">
+	<tbody>
+		<tr>
+			<th style="width: 25%">
+				Operation
+			</th>
+			<th>
+				Description
+			</th>
+		</tr>
+
+		<% _.each(connector.messages, function (message) { %>
+		<tr>
+			<td>
+				<em><%= message.title %></em>
+			</td>
+			<td>
+				<%= message.description || '' %>
+			</td>
+		</tr>
+		<% }) %>
+	</tbody>
+</table>
+
+<% }) %>

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,10 @@ var Falafel = function () {
 			// Spin up a dev server for testing via Postman on dev
 			if (options.dev === true) {
 				require('./devServer')(apptalk);
+				require('./docsGenerator')(options.directory);
 			}
+
+
 
 			return apptalk;
 

--- a/test/bindConnectors/formatInputBody/date.js
+++ b/test/bindConnectors/formatInputBody/date.js
@@ -150,7 +150,7 @@ describe('#date', function () {
     }
   });
 
-  it('should treat "now" as a special input value', function () {
+  it.only('should treat "now" as a special input value', function () {
     assert.strictEqual(
       formatDate('now', {
         type: 'string',

--- a/test/bindConnectors/formatInputBody/date.js
+++ b/test/bindConnectors/formatInputBody/date.js
@@ -150,7 +150,7 @@ describe('#date', function () {
     }
   });
 
-  it.only('should treat "now" as a special input value', function () {
+  it('should treat "now" as a special input value', function () {
     assert.strictEqual(
       formatDate('now', {
         type: 'string',

--- a/test/sample/docs.html
+++ b/test/sample/docs.html
@@ -1,0 +1,64 @@
+
+
+<h2>Configuration</h2>
+<table class="table-striped">
+	<tbody>
+		<tr>
+			<th style="width: 25%">
+				Operation
+			</th>
+			<th>
+				Description
+			</th>
+		</tr>
+
+		
+		<tr>
+			<td>
+				<em>Get list</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
+		<tr>
+			<td>
+				<em>Get lists</em>
+			</td>
+			<td>
+				Get a list of the lists in a user's MailChimp account.
+			</td>
+		</tr>
+		
+	</tbody>
+</table>
+
+
+
+<h2>Configuration</h2>
+<table class="table-striped">
+	<tbody>
+		<tr>
+			<th style="width: 25%">
+				Operation
+			</th>
+			<th>
+				Description
+			</th>
+		</tr>
+
+		
+		<tr>
+			<td>
+				<em>User subscribe</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
+	</tbody>
+</table>
+
+


### PR DESCRIPTION
* Create a Help Scout friendly docs table that can be copy and pasted - with all operations 
* If a trigger connector is included, also include a "Trigger Configuration" section that has a table for that too 