### PR TITLE
F/hash operations

### DIFF
--- a/example/connectors.json
+++ b/example/connectors.json
@@ -204,7 +204,12 @@
                         "primary": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "value",
+                        "primary",
+                        "label"
+                      ]
                     }
                   },
                   "email": {
@@ -221,7 +226,12 @@
                         "primary": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "value",
+                        "primary",
+                        "label"
+                      ]
                     }
                   },
                   "first_char": {

--- a/example/connectors/pipedrive/#hash_op/model.js
+++ b/example/connectors/pipedrive/#hash_op/model.js
@@ -1,0 +1,6 @@
+
+module.exports = function (params) {
+  return {
+      result: 'xyz'
+  };
+}

--- a/lib/bindConnectors/bindMessage.js
+++ b/lib/bindConnectors/bindMessage.js
@@ -16,6 +16,11 @@ module.exports = function (message, threadneedle, connectorConfig) {
 	// Nice method names only please
 	var methodName = camelCase(message.name);
 
+    //camelCasing loses the hash, so add it back if it was in the original name
+    if (message.name[0] === '#') {
+        methodName = '#' + methodName;
+    }
+
 	// Add the threadneedle method
 	threadneedle.addMethod(methodName, message.model);
 
@@ -26,21 +31,24 @@ module.exports = function (message, threadneedle, connectorConfig) {
 	// processes the inbound messages below.
 	return function (event) {
 		return when.promise(function (resolve, reject) {
-
-			var missingParams = getMissingParams(event.body, message.schema, connectorConfig.globalSchema);
+console.log(event);console.log(methodName);
+			var missingParams = (
+                methodName[0] === '#' ?
+                [] :
+                getMissingParams(event.body, message.schema, connectorConfig.globalSchema)
+            );
 
 			// If missing parameters, error before sending the API call
 			if (missingParams.length) {
+
 				return reject({
 					code: 'invalid_input',
 					message: 'The following required parameters are missing: ' + missingParams.join(', ')
 				});
-			}
 
-			// Otherwise run the method
-			else {
+			} else {   // Otherwise run the method
 
-        var body = formatInputBody(event.body, message.schema)
+                var body = formatInputBody(event.body, message.schema);
 
 				threadneedle[methodName](body)
 
@@ -52,6 +60,7 @@ module.exports = function (message, threadneedle, connectorConfig) {
                     },
                     reject
                 );
+
         	}
 
 		});

--- a/lib/bindConnectors/bindMessage.js
+++ b/lib/bindConnectors/bindMessage.js
@@ -31,7 +31,7 @@ module.exports = function (message, threadneedle, connectorConfig) {
 	// processes the inbound messages below.
 	return function (event) {
 		return when.promise(function (resolve, reject) {
-console.log(event);console.log(methodName);
+            
 			var missingParams = (
                 methodName[0] === '#' ?
                 [] :

--- a/lib/buildConnectorsJson/index.js
+++ b/lib/buildConnectorsJson/index.js
@@ -25,9 +25,9 @@ module.exports = function (directory, config) {
 		]);
 
 		connector.messages = _.filter(_.map(connectorConfig.messages, function (messageConfig) {
-
+			
 			// Some methods don't have schemas and should be hidden
-			if (!messageConfig.schema) {
+			if ( !messageConfig.schema || (messageConfig.name && messageConfig.name[0] === '#') ) {
 				return;
 			}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/test/buildConnectorsJson/index.js
+++ b/test/buildConnectorsJson/index.js
@@ -64,6 +64,27 @@ describe('#buildConnectorsJson', function () {
 		assert.equal(parsed[0].messages.length, 0);
 	});
 
+	it('should not add messages which start with "#" in their name', function () {
+		buildConnectorsJson('meh', [{
+			name: 'mailchimp',
+			messages: [{
+				name: '#my_message',
+				model: {
+					url: '..'
+				},
+				schema: {
+					input: {
+						name: {
+							type: 'string'
+						}
+					}
+				}
+			}]
+		}]);
+
+		assert.equal(parsed[0].messages.length, 0);
+	});
+
 	it('should add messages with schemas', function () {
 		buildConnectorsJson('meh', [{
 			name: 'mailchimp',


### PR DESCRIPTION
Added support for “special” operations which start with `#`; all such operations bypass input validation and are run as is - this should be considered as an “advanced” feature in falafel.