### PR TITLE
F/new required params format

### DIFF
--- a/lib/bindConnectors/getMissingParams.js
+++ b/lib/bindConnectors/getMissingParams.js
@@ -15,7 +15,6 @@ module.exports = function (params, messageSchema, globalSchema) {
     // Get the required keys from the message schema and the global schema
     var requiredKeys = [];
 
-
     var includeGlobals = true;
 
     // Add the required variables to the main array

--- a/lib/bindConnectors/getMissingParams.js
+++ b/lib/bindConnectors/getMissingParams.js
@@ -4,32 +4,54 @@
 * ensure it has all the required parameters.
 *
 * If any parameters exist, return an array of them.
+*
+* NOTE: this only validates at the top level of the schema.
 */
 var _ = require('lodash');
 
 
 module.exports = function (params, messageSchema, globalSchema) {
 
-    // Get the required keys from the message schema
-    var requiredKeys = [],
-        includeGlobals = true;
+    // Get the required keys from the message schema and the global schema
+    var requiredKeys = [];
+
+
+    var includeGlobals = true;
+
+    // Add the required variables to the main array
     if (messageSchema) {
+
+        // Set the message level required keys
+        if (_.isArray(messageSchema.required)) {
+            requiredKeys = messageSchema.required; 
+        }
+
+        // LEGACY: use the older `required` parameter on the property level
         _.each(messageSchema.input || {}, function (obj, key) {
             if (obj.required === true) {
                 requiredKeys.push(key);
             }
         });
+
         //if globals is specified locally, set it
         includeGlobals = ( _.isUndefined(messageSchema.globals) ? true : messageSchema.globals );
     }
 
     // ... and from the global schema unless explicitly excluded
     if (includeGlobals && globalSchema) {
+
+        // Add in the global required keys
+        if (_.isArray(globalSchema.required)) {
+            requiredKeys = _.union(requiredKeys, globalSchema.required); 
+        }
+
+        // LEGACY: add required field from the property level
         _.each(globalSchema.input || {}, function (obj, key) {
             if (obj.required === true) {
                 requiredKeys.push(key);
             }
         });
+
     }
 
 

--- a/lib/parseConfig/formatInputSchema.js
+++ b/lib/parseConfig/formatInputSchema.js
@@ -1,0 +1,4 @@
+
+module.exports = function (schema) {
+    
+}

--- a/lib/parseConfig/formatInputSchema.js
+++ b/lib/parseConfig/formatInputSchema.js
@@ -1,4 +1,0 @@
-
-module.exports = function (schema) {
-    
-}

--- a/lib/parseConfig/index.js
+++ b/lib/parseConfig/index.js
@@ -6,6 +6,7 @@ var _ 					= require('lodash');
 var getGlobalModel 		= require('./getGlobalModel');
 var getModel 			= require('./getModel');
 
+
 module.exports = function (config) {
 
 	if (_.isString(config)) {
@@ -41,6 +42,8 @@ module.exports = function (config) {
 		message.schema = {
 			name: operation.name,
 			input: operation.inputSchema.properties,
+			required: operation.inputSchema.required || [],
+			advanced: operation.inputSchema.advanced || [],
 		};
 
 		return message;

--- a/test/bindConnectors/getMissingParams.js
+++ b/test/bindConnectors/getMissingParams.js
@@ -213,4 +213,57 @@ describe('#getMissingParams', function () {
 	});
 
 
+	it('should handle the new schema format where properties are declared at the top', function () {
+
+		var missingParams = getMissingParams(
+			{
+				my_other_param: 'chris'
+			},
+			{
+				input: {
+					my_param: {
+						type: 'number',
+					},
+					my_other_param: {
+						type: 'string'
+					}
+				},
+				required: ['my_param']
+			},
+			undefined
+		);
+
+		assert.equal(missingParams[0], 'my_param');
+	})
+
+	it('should work with the new schema format where properties are declared at the top (global)', function () {
+
+		var missingParams = getMissingParams(
+			{
+				my_other_param: 'chris'
+			},
+			{
+				input: {
+					my_param: {
+						type: 'number',
+					},
+					my_other_param: {
+						type: 'string'
+					}
+				},
+			},
+			{
+				input: {
+					api_key: {
+						type: 'string',
+					}
+				},
+				required: ['api_key']
+			}
+		);
+
+		assert.equal(missingParams[0], 'api_key');
+	})
+
+
 });

--- a/test/bindConnectors/getMissingParams.js
+++ b/test/bindConnectors/getMissingParams.js
@@ -246,6 +246,7 @@ describe('#getMissingParams', function () {
 				input: {
 					my_param: {
 						type: 'number',
+						required: true
 					},
 					my_other_param: {
 						type: 'string'
@@ -262,7 +263,8 @@ describe('#getMissingParams', function () {
 			}
 		);
 
-		assert.equal(missingParams[0], 'api_key');
+		assert.equal(missingParams[0], 'my_param');
+		assert.equal(missingParams[1], 'api_key');
 	})
 
 


### PR DESCRIPTION
* Falafel can now validate `required` parameters when declared as an array at the top level of the schema, rather than the inline format (this is how new artisan connectors will work) 
* Marked the inline format as "legacy" in the comments