### PR TITLE
Ch6406/b/required fields null

### DIFF
--- a/lib/bindConnectors/getMissingParams.js
+++ b/lib/bindConnectors/getMissingParams.js
@@ -22,13 +22,24 @@ module.exports = function (params, messageSchema, globalSchema) {
 
         // Set the message level required keys
         if (_.isArray(messageSchema.required)) {
-            requiredKeys = messageSchema.required; 
+            requiredKeys = _.map(
+                messageSchema.required,
+                function (reqKey) {
+                    return {
+                        key: reqKey,
+                        type: messageSchema.input[reqKey].type
+                    };
+                }
+            );
         }
 
         // LEGACY: use the older `required` parameter on the property level
-        _.each(messageSchema.input || {}, function (obj, key) {
-            if (obj.required === true) {
-                requiredKeys.push(key);
+        _.each(messageSchema.input || {}, function (schemaObj, key) {
+            if (schemaObj.required === true) {
+                requiredKeys.push({
+                    key: key,
+                    type: schemaObj.type
+                });
             }
         });
 
@@ -41,24 +52,44 @@ module.exports = function (params, messageSchema, globalSchema) {
 
         // Add in the global required keys
         if (_.isArray(globalSchema.required)) {
-            requiredKeys = _.union(requiredKeys, globalSchema.required); 
+            requiredKeys = _.union(
+                requiredKeys,
+                _.map(
+                    globalSchema.required,
+                    function (reqKey) {
+                        return {
+                            key: reqKey,
+                            type: globalSchema.input[reqKey].type
+                        };
+                    }
+                )
+            );
         }
 
         // LEGACY: add required field from the property level
-        _.each(globalSchema.input || {}, function (obj, key) {
-            if (obj.required === true) {
-                requiredKeys.push(key);
+        _.each(globalSchema.input || {}, function (schemaObj, key) {
+            if (schemaObj.required === true) {
+                requiredKeys.push({
+                    key: key,
+                    type: schemaObj.type
+                });
             }
         });
 
     }
 
 
-    return _.reduce(requiredKeys, function (missingParams, key) {
-        if (_.isUndefined(params[key]) || params[key] === '') {
-            missingParams.push(key);
+    return _.reduce(requiredKeys, function (missingParams, reqObj) {
+        console.log(reqObj);
+        var missingCheck = (
+            _.isUndefined(params[reqObj.key]) ||
+            params[reqObj.key] === '' ||
+            ( _.isNull(params[reqObj.key]) && !_.includes(reqObj.type, 'null') )
+        );
+        if (missingCheck) {
+            missingParams.push(reqObj.key);
         }
-        return missingParams
+        return missingParams;
     }, []);
 
 };

--- a/lib/bindConnectors/getMissingParams.js
+++ b/lib/bindConnectors/getMissingParams.js
@@ -80,7 +80,6 @@ module.exports = function (params, messageSchema, globalSchema) {
 
 
     return _.reduce(requiredKeys, function (missingParams, reqObj) {
-        console.log(reqObj);
         var missingCheck = (
             _.isUndefined(params[reqObj.key]) ||
             params[reqObj.key] === '' ||

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@trayio/threadneedle": "^1.2.0",
+    "@trayio/threadneedle": "^1.2.2",
     "generate-schema": "^2.3.3",
     "knox": "^0.9.2",
     "lodash": "^4.1.0",

--- a/test/bindConnectors/getMissingParams.js
+++ b/test/bindConnectors/getMissingParams.js
@@ -3,7 +3,7 @@ var _ 	        = require('lodash');
 var getMissingParams = require('../../lib/bindConnectors/getMissingParams');
 
 
-describe('#getMissingParams', function () {
+describe.only('#getMissingParams', function () {
 
 	it('should pass - empty array', function () {
 
@@ -209,6 +209,59 @@ describe('#getMissingParams', function () {
 		);
 
 		assert(missingParams.length === 0);
+
+	});
+
+	it('should fail if property is null and null is not a specified type', function () {
+
+		var missingParams1 = getMissingParams(
+			{
+				test1: null,
+				test2: null
+			},
+			{
+
+				input: {
+					test1: {
+						type: 'null',
+						required: true
+					},
+					test2: {
+						type: ['number', 'null'],
+						required: true
+					}
+				}
+
+			},
+			undefined
+		);
+
+		assert(missingParams1.length === 0);
+
+
+		var missingParams2 = getMissingParams(
+			{
+				test1: null,
+				test2: null
+			},
+			{
+
+				input: {
+					test1: {
+						type: 'string',
+						required: true
+					},
+					test2: {
+						type: ['number'],
+						required: true
+					}
+				}
+
+			},
+			undefined
+		);
+
+		assert(missingParams2.length === 2);
 
 	});
 

--- a/test/bindConnectors/getMissingParams.js
+++ b/test/bindConnectors/getMissingParams.js
@@ -3,7 +3,7 @@ var _ 	        = require('lodash');
 var getMissingParams = require('../../lib/bindConnectors/getMissingParams');
 
 
-describe.only('#getMissingParams', function () {
+describe('#getMissingParams', function () {
 
 	it('should pass - empty array', function () {
 

--- a/test/bindConnectors/getMissingParams.js
+++ b/test/bindConnectors/getMissingParams.js
@@ -222,10 +222,6 @@ describe.only('#getMissingParams', function () {
 			{
 
 				input: {
-					test1: {
-						type: 'null',
-						required: true
-					},
 					test2: {
 						type: ['number', 'null'],
 						required: true
@@ -233,7 +229,14 @@ describe.only('#getMissingParams', function () {
 				}
 
 			},
-			undefined
+			{
+				input: {
+					test1: {
+						type: 'null',
+						required: true
+					}
+				}
+			}
 		);
 
 		assert(missingParams1.length === 0);
@@ -247,10 +250,6 @@ describe.only('#getMissingParams', function () {
 			{
 
 				input: {
-					test1: {
-						type: 'string',
-						required: true
-					},
 					test2: {
 						type: ['number'],
 						required: true
@@ -258,7 +257,14 @@ describe.only('#getMissingParams', function () {
 				}
 
 			},
-			undefined
+			{
+				input: {
+					test1: {
+						type: 'string',
+						required: true
+					}
+				}
+			}
 		);
 
 		assert(missingParams2.length === 2);


### PR DESCRIPTION
`null` is now processed in getMissing params.
If a field is `null` but is not a specified as a type, the field will be regarded as invalid