### PR TITLE
Fixed falafel reference and dynamic output processing

### DIFF
--- a/exampleTwo/connectors/testconnector/test_op2/model.js
+++ b/exampleTwo/connectors/testconnector/test_op2/model.js
@@ -1,10 +1,10 @@
 
 module.exports = {
 
-  method: 'get',
+	method: 'get',
 
-  url: 'test',
+	url: 'test',
 
 
 
-}
+};

--- a/exampleTwo/connectors/testconnector/test_op2/output.js
+++ b/exampleTwo/connectors/testconnector/test_op2/output.js
@@ -1,5 +1,4 @@
-module.exports = function () {
-	return when.promise(function (resolve, reject) {
-		return resolve('Hello');
-	});
+module.exports = function (params) {
+	console.log('calling');
+	return falafel.testconnector.testOp3(params);
 };

--- a/exampleTwo/connectors/testconnector/test_op3/model.js
+++ b/exampleTwo/connectors/testconnector/test_op3/model.js
@@ -1,0 +1,10 @@
+
+module.exports = function () {
+	return when.promise(function (resolve, reject) {
+		return resolve({
+			a: 'Hello',
+			b: 'World',
+			c: 123
+		});
+	});
+};

--- a/lib/bindConnectors/bindDynamicOutput.js
+++ b/lib/bindConnectors/bindDynamicOutput.js
@@ -10,21 +10,22 @@ module.exports = function (message, options) {
 
 			when(message.dynamicOutput(event.body))
 
-				.then(function (rawResponse) {
+			.then(function (rawResponse) {
 
-					if (!_.isObject(rawResponse)) return;
+				if (!_.isObject(rawResponse)) return {};
 
-					/*  If $schema exists on top level, assume its a JSON schema and set it.
-                    Else, GenerateSchema and then set.  */
-					return {
-						body: {
-							output_schema: ( rawResponse['$schema'] ? rawResponse : GenerateSchema.json(rawResponse) )
-						}
-					};
+				/*  If $schema exists on top level, assume its a JSON schema and set it.
+                Else, GenerateSchema and then set.  */
+				return {
+					headers: {},
+					body: {
+						output_schema: ( rawResponse['$schema'] ? rawResponse : GenerateSchema.json(rawResponse) )
+					}
+				};
 
-				})
+			})
 
-				.done(resolve, reject);
+			.done(resolve, reject);
 
 		});
 

--- a/lib/bindConnectors/bindMessage.js
+++ b/lib/bindConnectors/bindMessage.js
@@ -28,11 +28,9 @@ module.exports = function (message, threadneedle, connectorConfig) {
 	// Add the threadneedle method
 	threadneedle.addMethod(methodName, message.model);
 
-	/*
-		Add the threadneedle method to the falafel global
+	/*	Add the threadneedle method to the falafel global -
 		The falafel version of the operation should expose only
-		the body part of the response
-	*/
+		the body part of the response	*/
 	falafel[connectorName][methodName] = function (params) {
 		return when.promise(function (resolve, reject) {
 

--- a/lib/bindConnectors/bindMessage.js
+++ b/lib/bindConnectors/bindMessage.js
@@ -28,32 +28,26 @@ module.exports = function (message, threadneedle, connectorConfig) {
 	// Add the threadneedle method
 	threadneedle.addMethod(methodName, message.model);
 
-	// Add the threadneedle method to the falafel global
-	if (_.isFunction(message.model)) {
-		/*
-			If the model is a function, expose only the body part
-			of the response as the falafel operation
-		*/
-		falafel[connectorName][methodName] = function (params) {
-			return when.promise(function (resolve, reject) {
+	/*
+		Add the threadneedle method to the falafel global
+		The falafel version of the operation should expose only
+		the body part of the response
+	*/
+	falafel[connectorName][methodName] = function (params) {
+		return when.promise(function (resolve, reject) {
 
-				function getBody (resolver) {
-					return function (response) {
-						resolver(response.body);
-					};
-				}
+			function getBody (resolver) {
+				return function (response) {
+					resolver(response.body);
+				};
+			}
 
-				threadneedle[methodName](params)
+			threadneedle[methodName](params)
 
-				.done(getBody(resolve), getBody(reject));
+			.done(getBody(resolve), getBody(reject));
 
-			});
-		};
-	} else {
-		falafel[connectorName][methodName] = threadneedle[methodName];
-	}
-
-	// console.log(threadneedle[methodName]);
+		});
+	};
 
 	// Bind the method to the internal handler object - this is how the connector
 	// processes the inbound messages below.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
- There was a mistaken assumption that only function methods need to be wrapped, when in fact all threadneedle methods will need to be wrapped, since they all return the new response format
- Dynamic output processing shouldn’t crash now for non-valid responses