### PR TITLE
Trigger request getUniqueTriggerID and File handling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,16 +1,24 @@
 {
     "env": {
-        "node": true,
-        "commonjs": true,
-        "es6": true
+        "es6": true,
+        "node": true
     },
     "extends": "eslint:recommended",
     "globals": {
-        "_": false,
-        "falafel": true,
-        "when": false
+        "_": true,
+        "when": true,
+        "mout": true,
+        "falafel": true
     },
     "rules": {
+
+        #recommended overrides
+        "no-console": 1, #Use `// eslint-disable-next-line no-console` if you need to keep console.log
+        "no-unused-vars": 0,
+        "no-case-declarations": 0,
+        "no-inner-declarations": 0,
+
+        #global rules
         "indent": [
             "error",
             "tab",
@@ -22,17 +30,106 @@
                 "SwitchCase": 1
             }
         ],
+        "semi": [
+            "error",
+            "always"
+        ],
+        "quotes": [
+            "error",
+            "single",
+            {
+                "allowTemplateLiterals": true
+            }
+        ],
+        "keyword-spacing": "error",
+        "comma-spacing":  [
+            2,
+            {
+                "before": false,
+                "after": true
+            }
+        ],
+        "block-spacing": "error",
+        "space-before-blocks": [
+            "error",
+            "always"
+        ],
         "linebreak-style": [
             "error",
             "unix"
         ],
-        "quotes": [
+        "brace-style": [
             "error",
-            "single"
+            "1tbs",
+            {
+                "allowSingleLine": true
+            }
         ],
-        "semi": [
+
+        #function rules
+        "space-before-function-paren": [
             "error",
             "always"
+        ],
+        "function-paren-newline": [
+            "error",
+            "multiline"
+        ],
+        "func-call-spacing": [
+            "error",
+            "never"
+        ],
+        "wrap-iife": [
+            "error",
+            "inside"
+        ],
+        "arrow-parens": [
+            "error",
+            "always"
+        ],
+        "arrow-body-style": [
+            "error",
+            "always"
+        ],
+
+        #array rules
+        array-bracket-spacing: [
+            "error",
+            "always",
+            {
+                "singleValue": false,
+                "objectsInArrays": false
+            }
+        ],
+        "array-element-newline": [
+            "error",
+            "consistent"
+        ],
+        "array-bracket-newline": [
+            "error",
+            {
+                "multiline": true
+            }
+        ],
+
+        #object rules
+        "key-spacing": [
+            2,
+            {
+                beforeColon: false,
+                afterColon: true
+            }
+        ],
+        "object-curly-spacing": [
+            "error",
+            "always"
+        ],
+
+        #conditions
+        "multiline-ternary": [
+            "error",
+            "always-multiline"
         ]
-    }
+
+    },
 }

--- a/README.md
+++ b/README.md
@@ -276,37 +276,40 @@ This can be declared like so:
 ```js
 module.exports = {
 
-  // Filter function to determine whether the request should result
-  // in a workflow being triggered. If you want to pass all http requests
-  // to the connector then just return true here.
-  // NOTE: this is a sync-only method and does not accept promises.
-  filter: function (params, http) {
-    return (http.method === 'POST');
-  },
+	// Filter function to determine whether the request should result
+	// in a workflow being triggered. If you want to pass all http requests
+	// to the connector then just return true here.
+	// NOTE: this is a sync-only method and does not accept promises.
+	filter: function(params, http) {
+		return (http.method === 'POST');
+	},
 
-  // Async formatting and ad-hoc additional API function. Return a promise
-  // for async behaviour.
-  before: function (params, http) {
-    return {
-      data: http.body
-    };
-  },
+	// Async formatting and ad-hoc additional API function. Return a promise
+	// for async behaviour.
+	before: function(params, http) {
+		return {
+			data: http.body
+		};
+	},
 
-  // If you'd like to respond to the HTTP message from the third party because
-  // they're expecting a response (Salesforce notification), then also add a reply
-  // method here, passing a `http` object.
-  // NOTE: this is a sync-only method and does not accept promises.
-  reply: function (params, http, output) {
-    return {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/xml'
-      },
-      body: '<myxml>test</myxml>'
-    }
-  }
+	// If you'd like to respond to the HTTP message from the third party because
+	// they're expecting a response (Salesforce notification), then also add a reply
+	// method here, passing a `http` object.
+	reply: function(params, http, output) {
+		return {
+			status: 200,
+			headers: {
+				'Content-Type': 'application/xml'
+			},
+			body: '<myxml>test</myxml>'
+		}
+	},
 
-
+	// Use this function to set `trigger_deduplication_id` in the headers if
+	// there is a need to know the unique ID of the webhook being processed
+	getUniqueTriggerID: function (params, http, output) {
+		return http['uniqueWebhookID'];
+	}
 
 };
 ```

--- a/lib/bindConnectors/bindTriggerRequest.js
+++ b/lib/bindConnectors/bindTriggerRequest.js
@@ -73,7 +73,7 @@ module.exports = function (message, options) {
 									replyHttp.body = new Buffer(replyHttp.body).toString('base64');
 								}
 
-								when(getUniqueTriggerID(event.body.input, event.body.http))
+								when(getUniqueTriggerID(event.body.input, event.body.http, output))
 
 								.done(
 									function (uniqueTriggerID) {

--- a/lib/bindConnectors/bindTriggerRequest.js
+++ b/lib/bindConnectors/bindTriggerRequest.js
@@ -34,6 +34,10 @@ module.exports = function (message, options) {
 					return; // undefined is ok
 				};
 
+				var getUniqueTriggerID = message.request.getUniqueTriggerID || function () {
+					return; // undefined is ok
+				};
+
 
 				// Determine if we should trigger the workflow
 				when(filter(event.body.input, event.body.http))
@@ -69,14 +73,35 @@ module.exports = function (message, options) {
 									replyHttp.body = new Buffer(replyHttp.body).toString('base64');
 								}
 
-								resolve({
-									version: 2,
-									headers: {},
-									body: {
-										output: output,
-										http: replyHttp
-									}
-								});
+								when(getUniqueTriggerID(event.body.input, event.body.http))
+
+								.done(
+									function (uniqueTriggerID) {
+
+										var headersObj = {};
+
+										if (!_.isUndefined(uniqueTriggerID)) {
+											if (_.isString(uniqueTriggerID) || _.isNumber(uniqueTriggerID)) {
+												headersObj.trigger_deduplication_id = uniqueTriggerID;
+											} else {
+												return reject({
+													code: '#connector_error',
+													message: 'The result of getUniqueTriggerID is not a string or number.'
+												});
+											}
+										}
+
+										resolve({
+											version: 2,
+											headers: headersObj,
+											body: {
+												output: output,
+												http: replyHttp
+											}
+										});
+									},
+									reject
+								);
 
 							},
 							reject

--- a/lib/bindConnectors/bindTriggerRequest.js
+++ b/lib/bindConnectors/bindTriggerRequest.js
@@ -15,11 +15,11 @@ module.exports = function (message, options) {
 
 		// If the `request` handler is a function, run it, ensuring it's a promise
 		if (_.isFunction(message.request)) {
-			return when(message.request(event.body.input, event.body.http));
-		}
 
-		// If it's an object (simpler) type
-		else if (_.isObject(message.request)) {
+			return when(message.request(event.body.input, event.body.http));
+
+		} else if (_.isObject(message.request)) {	// If it's an object (simpler) type
+
 			return when.promise(function (resolve, reject) {
 
 				var filter = message.request.filter || function () {
@@ -122,9 +122,8 @@ module.exports = function (message, options) {
 					body: body
 				});
 			});
-		}
 
-		else {
+		} else {
 			throw new Error('The `request` file for this connector should be a function or an object.');
 		}
 

--- a/lib/bindConnectors/bindTriggerRequest.js
+++ b/lib/bindConnectors/bindTriggerRequest.js
@@ -1,12 +1,9 @@
 var _                = require('lodash');
 var when             = require('when');
-// var qs               = require('qs');
-// var formatError      = require('./formatError');
 var parseRequestBody = require('./parseRequestBody');
 
 
 module.exports = function (message, options) {
-	// console.log('Adding connector request handler:', message.name+'_request');
 
 	return function (event) {
 

--- a/lib/bindConnectors/bindTriggerRequest.js
+++ b/lib/bindConnectors/bindTriggerRequest.js
@@ -86,7 +86,8 @@ module.exports = function (message, options) {
 											} else {
 												return reject({
 													code: '#connector_error',
-													message: 'The result of getUniqueTriggerID is not a string or number.'
+													message: 'The result of getUniqueTriggerID is not a string or number.',
+													payload: uniqueTriggerID
 												});
 											}
 										}
@@ -99,6 +100,7 @@ module.exports = function (message, options) {
 												http: replyHttp
 											}
 										});
+
 									},
 									reject
 								);

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -283,12 +283,12 @@ module.exports = function (options) {
 				read_timeout: 0,
 				output: fileName,
 			}, function (err, res) {
-				if (err) {
-					reject(formatDownloadRejectObject(err));
-				} else if (res.statusCode !== 200) {
-					reject(formatDownloadRejectObject(new Error('Status code: ' + res.statusCode)));
-				} else {
 
+				if (err) {
+					return reject(formatDownloadRejectObject(err));
+				}
+
+				if (_.inRange(res.statusCode, 200, 300)) {
 					// Resolve with
 					resolve({
 						// The contents that was downloaded
@@ -299,7 +299,10 @@ module.exports = function (options) {
 						mime_type: file.mime_type,
 						expires: file.expires
 					});
+				} else {
+					reject(formatDownloadRejectObject(new Error('Status code: ' + res.statusCode)));
 				}
+
 			});
 
 		});
@@ -323,9 +326,7 @@ module.exports = function (options) {
 			)
 			.on('header', function (statusCode, headers) {
 
-				if (statusCode !== 200) {
-					reject(formatDownloadRejectObject(new Error('Status code: ' + statusCode)));
-				} else {
+				if (_.inRange(statusCode, 200, 300)) {
 					resolve({
 						// The contents as a stream
 						readStream: getStream,
@@ -335,6 +336,8 @@ module.exports = function (options) {
 						expires: file.expires,
 						size: headers['content-length']
 					});
+				} else {
+					reject(formatDownloadRejectObject(new Error('Status code: ' + statusCode)));
 				}
 
 			})

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -35,6 +35,17 @@ module.exports = function (options) {
 		}
 	}
 
+	//Standardising the error format for rejection during download attempt
+	function formatUploadRejectObject (rejectError) {
+		return {
+			code: '#connector_error',
+			payload: {
+				reason: 'An issue has occured when attempting to upload the file.',
+				error: rejectError.message || undefined
+			}
+		};
+	}
+
 	/*
 		Upload a file to S3.
 	*/
@@ -91,7 +102,7 @@ module.exports = function (options) {
 				if (fileUploadError) {
 					// eslint-disable-next-line no-console
 					console.log('fileUploadError', fileUploadError);
-					return reject(fileUploadError);
+					return reject(formatUploadRejectObject(fileUploadError));
 				}
 
 				var twentyFourHourPeriod = moment().add(1, 'days');
@@ -108,7 +119,7 @@ module.exports = function (options) {
 						if (fileUploadSigningError) {
 							// eslint-disable-next-line no-console
 							console.log('fileUploadSigningError', fileUploadSigningError);
-							return reject(fileUploadSigningError);
+							return reject(formatUploadRejectObject(fileUploadError));
 						}
 
 						resolve({
@@ -192,7 +203,7 @@ module.exports = function (options) {
 					if (fileUploadError) {
 						// eslint-disable-next-line no-console
 						console.log('fileUploadError', fileUploadError);
-						return reject(fileUploadError);
+						return reject(formatUploadRejectObject(fileUploadError));
 					}
 
 					var twentyFourHourPeriod = moment().add(1, 'days');
@@ -209,7 +220,7 @@ module.exports = function (options) {
 							if (fileUploadSigningError) {
 								// eslint-disable-next-line no-console
 								console.log('fileUploadSigningError', fileUploadSigningError);
-								return reject(fileUploadSigningError);
+								return reject(formatUploadRejectObject(fileUploadSigningError));
 							}
 
 							resolve({
@@ -231,6 +242,17 @@ module.exports = function (options) {
 
 
 
+	//Standardising the error format for rejection during upload attempt
+	function formatDownloadRejectObject (rejectError) {
+		return {
+			code: '#connector_error',
+			payload: {
+				reason: 'An issue has occured when attempting to download the file.',
+				error: rejectError.message || undefined
+			}
+		};
+	}
+
 	/*
 		Download a file from S3. The object passed here should have been one that
 		was returned via the `upload` function above in a previous workflow step.
@@ -247,9 +269,9 @@ module.exports = function (options) {
 				output: fileName,
 			}, function (err, res) {
 				if (err) {
-					reject(err);
+					reject(formatDownloadRejectObject(err));
 				} else if (res.statusCode !== 200) {
-					reject(new Error(res.statusCode));
+					reject(formatDownloadRejectObject(new Error(res.statusCode)));
 				} else {
 
 					// Resolve with
@@ -287,7 +309,7 @@ module.exports = function (options) {
 			.on('header', function (statusCode, headers) {
 
 				if (statusCode !== 200) {
-					reject(new Error(statusCode));
+					reject(formatDownloadRejectObject(new Error(statusCode)));
 				} else {
 					resolve({
 						// The contents as a stream
@@ -299,8 +321,9 @@ module.exports = function (options) {
 						size: headers['content-length']
 					});
 				}
+
 			})
-			.on('err', reject);
+			.on('err', formatDownloadRejectObject);
 
 		});
 	};

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -18,7 +18,7 @@ module.exports = function (options) {
 
 	//Handling development mode
 	function checkDevConfig () {
-		if (process.env.NODE_ENV === 'development' && _.isUndefined(options.aws) && _.isUndefined(process.env.AWS_ACCESS_KEY_ID)) {
+		if (process.env.NODE_ENV === 'development' && _.isUndefined(options.aws) && _.isUndefined(process.env.AWS_ACCESS_KEY_ID) && _.isUndefined(process.env.AWS_PROFILE)) {
 			return new Error('For development and testing please require an aws.json file with `key` and `secret` or add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the environment.');
 		}
 	}
@@ -39,8 +39,8 @@ module.exports = function (options) {
 	function formatUploadRejectObject (rejectError) {
 		return {
 			code: '#connector_error',
+			message: 'An issue has occured when attempting to upload the file.',
 			payload: {
-				reason: 'An issue has occured when attempting to upload the file.',
 				error: rejectError.message || undefined
 			}
 		};
@@ -59,7 +59,10 @@ module.exports = function (options) {
 		return when.promise(function (resolve, reject) {
 
 			if (_.isUndefined(params.length)) {
-				return reject(new Error('`length` must be specified for file uploading.'));
+				return reject({
+					code: '#connector_error',
+					message: '`length` must be specified for file uploading.'
+				});
 			}
 
 			//Generate a random file name
@@ -88,7 +91,10 @@ module.exports = function (options) {
 
 				var contentBuffer = params.contents;
 				if (!util.isBuffer(contentBuffer)) {
-					return reject(new Error('Please pass the `contents` as a Node.js Buffer.'));
+					return reject({
+						code: '#connector_error',
+						message: 'Please pass the `contents` as a Node.js Buffer.'
+					});
 				} else {
 					uploadParams.Body = contentBuffer;
 				}
@@ -101,7 +107,7 @@ module.exports = function (options) {
 
 				if (fileUploadError) {
 					// eslint-disable-next-line no-console
-					console.log('fileUploadError', fileUploadError);
+					console.error('[ERROR] fileUploadError', fileUploadError);
 					return reject(formatUploadRejectObject(fileUploadError));
 				}
 
@@ -118,7 +124,7 @@ module.exports = function (options) {
 
 						if (fileUploadSigningError) {
 							// eslint-disable-next-line no-console
-							console.log('fileUploadSigningError', fileUploadSigningError);
+							console.error('[ERROR] fileUploadSigningError', fileUploadSigningError);
 							return reject(formatUploadRejectObject(fileUploadError));
 						}
 
@@ -149,11 +155,17 @@ module.exports = function (options) {
 		}
 
 		if (_.isUndefined(params.readStream) || _.isUndefined(params.readStream.pipe)) {
-			return when.reject(new Error('The object passed in must contain the property \'readStream\', referecing a read stream.'));
+			return when.reject({
+				code: '#connector_error',
+				message: 'The object passed in must contain the property \'readStream\', referecing a read stream.'
+			});
 		}
 
 		if (_.isUndefined(params.length)) {
-			return when.reject(new Error('`length` must be specified for file uploading.'));
+			return when.reject({
+				code: '#connector_error',
+				message: '`length` must be specified for file uploading.'
+			});
 		}
 
 		return streamMPUpload(params);
@@ -172,7 +184,10 @@ module.exports = function (options) {
 		}
 
 		if (_.isUndefined(params.readStream) || _.isUndefined(params.readStream.pipe)) {
-			return when.reject(new Error('The object passed in must contain the property \'readStream\', referecing a read stream.'));
+			return when.reject({
+				code: '#connector_error',
+				message: 'The object passed in must contain the property \'readStream\', referecing a read stream.'
+			});
 		}
 
 		return when.promise(function (resolve, reject) {
@@ -202,7 +217,7 @@ module.exports = function (options) {
 
 					if (fileUploadError) {
 						// eslint-disable-next-line no-console
-						console.log('fileUploadError', fileUploadError);
+						console.error('[ERROR] fileUploadError', fileUploadError);
 						return reject(formatUploadRejectObject(fileUploadError));
 					}
 
@@ -219,7 +234,7 @@ module.exports = function (options) {
 
 							if (fileUploadSigningError) {
 								// eslint-disable-next-line no-console
-								console.log('fileUploadSigningError', fileUploadSigningError);
+								console.error('[ERROR] fileUploadSigningError', fileUploadSigningError);
 								return reject(formatUploadRejectObject(fileUploadSigningError));
 							}
 
@@ -246,8 +261,8 @@ module.exports = function (options) {
 	function formatDownloadRejectObject (rejectError) {
 		return {
 			code: '#connector_error',
+			message: 'An issue has occured when attempting to download the file.',
 			payload: {
-				reason: 'An issue has occured when attempting to download the file.',
 				error: rejectError.message || undefined
 			}
 		};

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -286,7 +286,7 @@ module.exports = function (options) {
 				if (err) {
 					reject(formatDownloadRejectObject(err));
 				} else if (res.statusCode !== 200) {
-					reject(formatDownloadRejectObject(new Error(res.statusCode)));
+					reject(formatDownloadRejectObject(new Error('Status code: ' + res.statusCode)));
 				} else {
 
 					// Resolve with
@@ -324,7 +324,7 @@ module.exports = function (options) {
 			.on('header', function (statusCode, headers) {
 
 				if (statusCode !== 200) {
-					reject(formatDownloadRejectObject(new Error(statusCode)));
+					reject(formatDownloadRejectObject(new Error('Status code: ' + statusCode)));
 				} else {
 					resolve({
 						// The contents as a stream

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -4,23 +4,34 @@ var util   = require('util');
 var when   = require('when');
 var guid   = require('mout/random/guid');
 var mime   = require('mime');
+var moment = require('moment');
 
 var needle = require('needle');
 // var knox   = require('knox');
 
 var AWS = require('aws-sdk');
 
+var REGION = 'us-west-2',
+	BUCKET = 'workflow-file-uploads';
+
 
 module.exports = function (options) {
 
+	function checkDevConfig () {
+		if (process.env.NODE_ENV === 'development' && _.isUndefined(options.aws) && _.isUndefined(process.env.AWS_ACCESS_KEY_ID)) {
+			return new Error('For development and testing please require an aws.json file with `key` and `secret` or add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the environment.');
+		}
+	}
+
 
 	//Pull the AWS creds from environment if present
-	if (!_.isObject(options.aws)) {
-		if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
-			options.aws = {
-				key: process.env.AWS_ACCESS_KEY_ID,
-				secret: process.env.AWS_SECRET_ACCESS_KEY
-			};
+	if (_.isPlainObject(options.aws)) {
+		var specifiedCreds = options.aws;
+		if (specifiedCreds.key && specifiedCreds.secret) {
+			AWS.config.update({
+				accessKeyId: specifiedCreds.key,
+				secretAccessKey: specifiedCreds.secret
+			});
 		}
 	}
 
@@ -28,188 +39,114 @@ module.exports = function (options) {
 		Upload a file to S3.
 	*/
 	var upload = function (params) {
+
+		var errorCheck = checkDevConfig();
+		if (_.isError(errorCheck)) {
+			return when.reject(errorCheck);
+		}
+
 		return when.promise(function (resolve, reject) {
 
-			if (!_.isObject(options.aws)) {
-				return reject(new Error('AWS config not specified. Add a aws.json file in the connector folder, and pass it to falafel.'));
+			if (_.isUndefined(params.length)) {
+				return reject(new Error('`length` must be specified for file uploading.'));
 			}
 
-			var uploadConfig = {
-				Bucket: 'us-west-2'
+			//Generate a random file name
+			var fileGuidName = guid();
+
+			//Get mimeType
+			var mimeType = params.contentType || mime.lookup(params.name);
+
+			//Setup params for `s3.upload` method
+			var uploadParams = {
+				Bucket: BUCKET,
+				Key: fileGuidName,
+				ContentType: mimeType,
+				ContentLength: params.length
 			};
 
-			// var client = knox.createClient({
-			// 	key: options.aws.key,
-			// 	secret: options.aws.secret,
-			// 	bucket: 'workflow-file-uploads',
-			// 	region: 'us-west-2'
-			// });
+			//Set relavant Body
+			if (params.file) {	// NEW
 
+				uploadParams.Body = fs.createReadStream(params.file);
 
-			// Generate a random file name
-			var fileName = guid();
-
-			// TODO: should we pass the content-type to S3?
-			var mimeType = params.contentType || mime.lookup(params.name);
-			// var headers = {
-			// 	'Content-Type': mimeType,
-			// };
-			uploadConfig.ContentType = mimeType;
-
-			// NEW
-			if (params.file) {
-
-				uploadConfig.ContentLength = params.length;
-
-				uploadConfig.Body = fs.createReadStream(params.file);
-
-				var s3 = new AWS.S3({region: 'us-west-2'});
-
-				s3.upload(uploadConfig, function (uploadErr, data) {
-
-					if (uploadErr) {
-						// eslint-disable-next-line no-console
-						console.log('uploadErr', uploadErr);
-						return reject(uploadErr);
-					}
-
-					var twentyFourHours = new Date(Date.now() + 24 * 60 * 60000);
-					// var signedUrl = client.signedUrl(fileName, twentyFourHours);
-
-					//data.url ???
-
-					// Resolve with an object following the "file" schema
-					resolve({
-						name: params.name,
-						// url: signedUrl,
-						mime_type: mimeType,
-						expires: Math.round(twentyFourHours.getTime() / 1000)
-					});
-
-				});
-
-				// var req = client.put(fileName, {
-				// 	'Content-Length': params.length
-				// 	, 'Content-Type': mimeType,
-				// });
-
-				// fs.createReadStream(params.file).pipe(req);
-
-				// req.on('response', function(res){
-				// 	if (res.statusCode !== 200) {
-				// 		reject(new Error(res.statusCode));
-				// 	} else {
-				// 		var twentyFourHours = new Date(Date.now() + 24 * 60 * 60000);
-				// 		var signedUrl = client.signedUrl(fileName, twentyFourHours);
-				//
-				// 		// Resolve with an object following the "file" schema
-				// 		resolve({
-				// 			name: params.name,
-				// 			url: signedUrl,
-				// 			mime_type: mimeType,
-				// 			expires: Math.round(twentyFourHours.getTime() / 1000)
-				// 		});
-				// 	}
-				// });
-				//
-				// req.on('error', reject);
-
-			}
-
-			// OLD
-			else {
+			} else {	// OLD
 
 				// eslint-disable-next-line no-console
 				console.warn('Dev warning - this is using the old upload mechanism; please use `file` (the path to the local file) instead of `contents`.');
 
-				var buffer;
-				if (!util.isBuffer(params.contents)) {
-					return when.reject(new Error('Please pass the `contents` as a Node.js Buffer.'));
+				var contentBuffer = params.contents;
+				if (!util.isBuffer(contentBuffer)) {
+					return reject(new Error('Please pass the `contents` as a Node.js Buffer.'));
 				} else {
-					buffer = params.contents;
+					uploadParams.Body = contentBuffer;
 				}
 
-				// Stick the buffer in S3
-				client.putBuffer(buffer, fileName, headers, function (err, res) {
-					if (err) {
-						reject(err);
-					} else if (res.statusCode !== 200) {
-						reject(new Error(res.statusCode));
-					} else {
-						var twentyFourHours = new Date(Date.now() + 24 * 60 * 60000);
-						var signedUrl = client.signedUrl(fileName, twentyFourHours);
+			}
 
-						// Resolve with an object following the "file" schema
+			var s3 = new AWS.S3({ region: REGION });
+
+			s3.upload(uploadParams, function (fileUploadError, data) {
+
+				if (fileUploadError) {
+					// eslint-disable-next-line no-console
+					console.log('fileUploadError', fileUploadError);
+					return reject(fileUploadError);
+				}
+
+				var twentyFourHourPeriod = moment().add(1, 'days');
+
+				s3.getSignedUrl(
+					'getObject',
+					{
+						Bucket: BUCKET,
+						Key: fileGuidName,
+						Expires: twentyFourHourPeriod.unix() - moment().unix()
+					},
+					function (fileUploadSigningError, signedUrl) {
+
+						if (fileUploadSigningError) {
+							// eslint-disable-next-line no-console
+							console.log('fileUploadSigningError', fileUploadSigningError);
+							return reject(fileUploadSigningError);
+						}
+
 						resolve({
 							name: params.name,
 							url: signedUrl,
 							mime_type: mimeType,
-							expires: Math.round(twentyFourHours.getTime() / 1000)
+							expires: twentyFourHourPeriod.unix()
 						});
-					}
-				});
 
-			}
+					}
+				);
+
+			});
 
 		});
 	};
-
 
 	/*
 		A stream variant of upload, requiring a `readStream` property
 		instead of a `file` property
 	*/
 	var streamUpload = function (params) {
-		return when.promise(function (resolve, reject) {
 
-			if (!_.isObject(options.aws)) {
-				return reject(new Error('AWS config not specified. Add a aws.json file in the connector folder, and pass it to falafel.'));
-			}
+		var errorCheck = checkDevConfig();
+		if (_.isError(errorCheck)) {
+			return when.reject(errorCheck);
+		}
 
-			if (_.isUndefined(params.readStream) || _.isUndefined(params.readStream.pipe)) {
-				return reject(new Error('The object passed in must contain the property \'readStream\', referecing a read stream.'));
-			}
+		if (_.isUndefined(params.readStream) || _.isUndefined(params.readStream.pipe)) {
+			return when.reject(new Error('The object passed in must contain the property \'readStream\', referecing a read stream.'));
+		}
 
-			var client = knox.createClient({
-				key: options.aws.key,
-				secret: options.aws.secret,
-				bucket: 'workflow-file-uploads',
-				region: 'us-west-2'
-			});
+		if (_.isUndefined(params.length)) {
+			return when.reject(new Error('`length` must be specified for file uploading.'));
+		}
 
+		return streamMPUpload(params);
 
-			// Generate a random file name
-			var fileName = guid();
-
-			var mimeType = params.contentType || mime.lookup(params.name);
-
-			var req = client.put(fileName, {
-				'Content-Length': params.length,
-				'Content-Type': mimeType,
-			});
-
-			params.readStream.pipe(req);
-
-			req.on('response', function(res){
-				if (res.statusCode !== 200) {
-					reject(new Error(res.statusCode));
-				} else {
-					var twentyFourHours = new Date(Date.now() + 24 * 60 * 60000);
-					var signedUrl = client.signedUrl(fileName, twentyFourHours);
-
-					// Resolve with an object following the "file" schema
-					resolve({
-						name: params.name,
-						url: signedUrl,
-						mime_type: mimeType,
-						expires: Math.round(twentyFourHours.getTime() / 1000)
-					});
-				}
-			});
-
-			req.on('error', reject);
-
-		});
 	};
 
 	/*
@@ -217,73 +154,79 @@ module.exports = function (options) {
 		absolutely now way of uploading with the content-length header set.
 	*/
 	var streamMPUpload = function (params) {
+
+		var errorCheck = checkDevConfig();
+		if (_.isError(errorCheck)) {
+			return when.reject(errorCheck);
+		}
+
+		if (_.isUndefined(params.readStream) || _.isUndefined(params.readStream.pipe)) {
+			return when.reject(new Error('The object passed in must contain the property \'readStream\', referecing a read stream.'));
+		}
+
 		return when.promise(function (resolve, reject) {
 
-			if (options.dev) {
-				// eslint-disable-next-line no-console
-				console.warn('Dev warning - avoid using streamMPUpload if possible.');
+			//Generate a random file name
+			var fileGuidName = guid();
+
+			//Get mimeType
+			var mimeType = params.contentType || mime.lookup(params.name);
+
+			var uploadParams = {
+				Bucket: BUCKET,
+				Key: fileGuidName,
+				ContentType: mimeType,
+				Body: params.readStream
+			};
+
+			if (!_.isUndefined(params.length)) {
+				uploadParams.ContentLength = params.length;
 			}
 
-			try { //Check if the lib has been included
-				require.resolve('knox-mpu-alt');
-			} catch (e) {
-				return reject(new Error('Please install `knox-mpu-alt` library and save it as a dependency to use streamMPUpload.'));
-			}
+			var s3 = new AWS.S3({ region: REGION });
 
-			var knoxMPU = require('knox-mpu-alt');
+			s3.upload(
+				uploadParams,
+				function (fileUploadError, data) {
 
-			if (!_.isObject(options.aws)) {
-				return reject(new Error('AWS config not specified. Add a aws.json file in the connector folder, and pass it to falafel.'));
-			}
-
-			if (_.isUndefined(params.readStream) || _.isUndefined(params.readStream.pipe)) {
-				return reject(new Error('The object passed in must contain the property \'readStream\', referecing a read stream.'));
-			}
-
-			//Instantiate knox client
-			var client = knox.createClient({
-				key: options.aws.key,
-				secret: options.aws.secret,
-				bucket: 'workflow-file-uploads',
-				region: 'us-west-2'
-			});
-
-
-			// Generate a random file name and get mimeType
-			var fileName = guid(),
-				mimeType = params.contentType || mime.lookup(params.name);
-
-			//Instantiate knoxMPU instance with the knox client, stream, and metaData
-			new knoxMPU(
-				{
-					client: client,
-					objectName: fileName,
-					stream: params.readStream,
-					headers: {
-						'Content-Type': mimeType,
-					}
-				},
-				function(mpuUploadErr) {
-
-					if (mpuUploadErr) {
-						return reject(mpuUploadErr);
+					if (fileUploadError) {
+						// eslint-disable-next-line no-console
+						console.log('fileUploadError', fileUploadError);
+						return reject(fileUploadError);
 					}
 
-					var twentyFourHours = new Date(Date.now() + 24 * 60 * 60000);
-					var signedUrl = client.signedUrl(fileName, twentyFourHours);
+					var twentyFourHourPeriod = moment().add(1, 'days');
 
-					// Resolve with an object following the tray "file" schema
-					resolve({
-						name: params.name,
-						url: signedUrl,
-						mime_type: mimeType,
-						expires: Math.round(twentyFourHours.getTime() / 1000)
-					});
+					s3.getSignedUrl(
+						'getObject',
+						{
+							Bucket: BUCKET,
+							Key: fileGuidName,
+							Expires: twentyFourHourPeriod.unix() - moment().unix()
+						},
+						function (fileUploadSigningError, signedUrl) {
+
+							if (fileUploadSigningError) {
+								// eslint-disable-next-line no-console
+								console.log('fileUploadSigningError', fileUploadSigningError);
+								return reject(fileUploadSigningError);
+							}
+
+							resolve({
+								name: params.name,
+								url: signedUrl,
+								mime_type: mimeType,
+								expires: twentyFourHourPeriod.unix()
+							});
+
+						}
+					);
 
 				}
 			);
 
 		});
+
 	};
 
 

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -73,7 +73,7 @@ module.exports = function (options) {
 
 			//Setup params for `s3.upload` method
 			var uploadParams = {
-				Bucket: BUCKET,
+				Bucket: params.bucket || BUCKET,
 				Key: fileGuidName,
 				ContentType: mimeType,
 				ContentLength: params.length
@@ -101,7 +101,7 @@ module.exports = function (options) {
 
 			}
 
-			var s3 = new AWS.S3({ region: REGION });
+			var s3 = new AWS.S3({ region: params.region || REGION });
 
 			s3.upload(uploadParams, function (fileUploadError, data) {
 
@@ -116,7 +116,7 @@ module.exports = function (options) {
 				s3.getSignedUrl(
 					'getObject',
 					{
-						Bucket: BUCKET,
+						Bucket: params.bucket || BUCKET,
 						Key: fileGuidName,
 						Expires: twentyFourHourPeriod.unix() - moment().unix()
 					},
@@ -199,7 +199,7 @@ module.exports = function (options) {
 			var mimeType = params.contentType || mime.lookup(params.name);
 
 			var uploadParams = {
-				Bucket: BUCKET,
+				Bucket: params.bucket || BUCKET,
 				Key: fileGuidName,
 				ContentType: mimeType,
 				Body: params.readStream
@@ -209,7 +209,7 @@ module.exports = function (options) {
 				uploadParams.ContentLength = params.length;
 			}
 
-			var s3 = new AWS.S3({ region: REGION });
+			var s3 = new AWS.S3({ region: params.region || REGION });
 
 			s3.upload(
 				uploadParams,
@@ -226,7 +226,7 @@ module.exports = function (options) {
 					s3.getSignedUrl(
 						'getObject',
 						{
-							Bucket: BUCKET,
+							Bucket: params.bucket || BUCKET,
 							Key: fileGuidName,
 							Expires: twentyFourHourPeriod.unix() - moment().unix()
 						},

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -6,7 +6,9 @@ var guid   = require('mout/random/guid');
 var mime   = require('mime');
 
 var needle = require('needle');
-var knox   = require('knox');
+// var knox   = require('knox');
+
+var AWS = require('aws-sdk');
 
 
 module.exports = function (options) {
@@ -32,12 +34,16 @@ module.exports = function (options) {
 				return reject(new Error('AWS config not specified. Add a aws.json file in the connector folder, and pass it to falafel.'));
 			}
 
-			var client = knox.createClient({
-				key: options.aws.key,
-				secret: options.aws.secret,
-				bucket: 'workflow-file-uploads',
-				region: 'us-west-2'
-			});
+			var uploadConfig = {
+				Bucket: 'us-west-2'
+			};
+
+			// var client = knox.createClient({
+			// 	key: options.aws.key,
+			// 	secret: options.aws.secret,
+			// 	bucket: 'workflow-file-uploads',
+			// 	region: 'us-west-2'
+			// });
 
 
 			// Generate a random file name
@@ -45,43 +51,76 @@ module.exports = function (options) {
 
 			// TODO: should we pass the content-type to S3?
 			var mimeType = params.contentType || mime.lookup(params.name);
-			var headers = {
-				'Content-Type': mimeType,
-			};
+			// var headers = {
+			// 	'Content-Type': mimeType,
+			// };
+			uploadConfig.ContentType = mimeType;
 
 			// NEW
 			if (params.file) {
 
-				var req = client.put(fileName, {
-					'Content-Length': params.length
-					, 'Content-Type': mimeType,
-				});
+				uploadConfig.ContentLength = params.length;
 
-				fs.createReadStream(params.file).pipe(req);
+				uploadConfig.Body = fs.createReadStream(params.file);
 
-				req.on('response', function(res){
-					if (res.statusCode !== 200) {
-						reject(new Error(res.statusCode));
-					} else {
-						var twentyFourHours = new Date(Date.now() + 24 * 60 * 60000);
-						var signedUrl = client.signedUrl(fileName, twentyFourHours);
+				var s3 = new AWS.S3({region: 'us-west-2'});
 
-						// Resolve with an object following the "file" schema
-						resolve({
-							name: params.name,
-							url: signedUrl,
-							mime_type: mimeType,
-							expires: Math.round(twentyFourHours.getTime() / 1000)
-						});
+				s3.upload(uploadConfig, function (uploadErr, data) {
+
+					if (uploadErr) {
+						// eslint-disable-next-line no-console
+						console.log('uploadErr', uploadErr);
+						return reject(uploadErr);
 					}
+
+					var twentyFourHours = new Date(Date.now() + 24 * 60 * 60000);
+					// var signedUrl = client.signedUrl(fileName, twentyFourHours);
+
+					//data.url ???
+
+					// Resolve with an object following the "file" schema
+					resolve({
+						name: params.name,
+						// url: signedUrl,
+						mime_type: mimeType,
+						expires: Math.round(twentyFourHours.getTime() / 1000)
+					});
+
 				});
 
-				req.on('error', reject);
+				// var req = client.put(fileName, {
+				// 	'Content-Length': params.length
+				// 	, 'Content-Type': mimeType,
+				// });
+
+				// fs.createReadStream(params.file).pipe(req);
+
+				// req.on('response', function(res){
+				// 	if (res.statusCode !== 200) {
+				// 		reject(new Error(res.statusCode));
+				// 	} else {
+				// 		var twentyFourHours = new Date(Date.now() + 24 * 60 * 60000);
+				// 		var signedUrl = client.signedUrl(fileName, twentyFourHours);
+				//
+				// 		// Resolve with an object following the "file" schema
+				// 		resolve({
+				// 			name: params.name,
+				// 			url: signedUrl,
+				// 			mime_type: mimeType,
+				// 			expires: Math.round(twentyFourHours.getTime() / 1000)
+				// 		});
+				// 	}
+				// });
+				//
+				// req.on('error', reject);
 
 			}
 
 			// OLD
 			else {
+
+				// eslint-disable-next-line no-console
+				console.warn('Dev warning - this is using the old upload mechanism; please use `file` (the path to the local file) instead of `contents`.');
 
 				var buffer;
 				if (!util.isBuffer(params.contents)) {
@@ -325,11 +364,14 @@ module.exports = function (options) {
 
 
 	falafel.files = {
+
 		upload: upload,
 		streamUpload: streamUpload,
 		streamMPUpload: streamMPUpload,
+
 		download: download,
 		streamDownload: streamDownload
+
 	};
 
 };

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -7,7 +7,6 @@ var mime   = require('mime');
 var moment = require('moment');
 
 var needle = require('needle');
-// var knox   = require('knox');
 
 var AWS = require('aws-sdk');
 
@@ -17,12 +16,12 @@ var REGION = 'us-west-2',
 
 module.exports = function (options) {
 
+	//Handling development mode
 	function checkDevConfig () {
 		if (process.env.NODE_ENV === 'development' && _.isUndefined(options.aws) && _.isUndefined(process.env.AWS_ACCESS_KEY_ID)) {
 			return new Error('For development and testing please require an aws.json file with `key` and `secret` or add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the environment.');
 		}
 	}
-
 
 	//Pull the AWS creds from environment if present
 	if (_.isPlainObject(options.aws)) {
@@ -34,6 +33,7 @@ module.exports = function (options) {
 			});
 		}
 	}
+
 
 	//Standardising the error format for rejection during download attempt
 	function formatUploadRejectObject (rejectError) {
@@ -327,6 +327,7 @@ module.exports = function (options) {
 
 		});
 	};
+
 
 
 	falafel.files = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -29,6 +29,7 @@
     "when": "^3.7.8"
   },
   "devDependencies": {
+    "aws-sdk": "^2.361.0",
     "body-parser": "^1.18.3",
     "eslint": "^4.19.1",
     "express": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@trayio/threadneedle": "^1.5.1",
     "generate-schema": "^2.6.0",
-    "knox": "^0.9.2",
     "lodash": "^4.17.11",
     "mime": "^1.6.0",
     "moment": "^2.22.2",
@@ -35,7 +34,6 @@
     "express": "^4.16.4",
     "grunt": "^0.4.5",
     "grunt-mocha-test": "^0.12.7",
-    "knox-mpu-alt": "^0.2.2",
     "mocha": "^2.5.3",
     "mocha-unfunk-reporter": "^0.4.0",
     "proxyquire": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "aws-sdk": "^2.361.0",
     "body-parser": "^1.18.3",
-    "eslint": "^4.19.1",
+    "eslint": "^5.9.0",
     "express": "^4.16.4",
     "grunt": "^0.4.5",
     "grunt-mocha-test": "^0.12.7",

--- a/test/bindConnectors/bindTriggerRequest.js
+++ b/test/bindConnectors/bindTriggerRequest.js
@@ -4,7 +4,7 @@ var when		= require('when');
 
 var bindTriggerRequest = require('../../lib/bindConnectors/bindTriggerRequest');
 
-describe.only('#bindTrigger', function () {
+describe('#bindTrigger', function () {
 
 	var devOptions = {
 		dev: true

--- a/test/bindConnectors/bindTriggerRequest.js
+++ b/test/bindConnectors/bindTriggerRequest.js
@@ -4,7 +4,7 @@ var when		= require('when');
 
 var bindTriggerRequest = require('../../lib/bindConnectors/bindTriggerRequest');
 
-describe('#bindTrigger', function () {
+describe.only('#bindTrigger', function () {
 
 	var devOptions = {
 		dev: true
@@ -315,6 +315,282 @@ describe('#bindTrigger', function () {
 			},
 			function (err) {
 				assert.fail(err);
+				done();
+			}
+		);
+
+	});
+
+
+	it('should set trigger_deduplication_id when getUniqueTriggerID returns a valid string', function (done) {
+		this.slow(1200);
+
+		var returnBody = { test: 123 };
+
+		var requestFunc = bindTriggerRequest(
+			{
+				request: {
+					reply: function () {
+						return {
+							body: returnBody
+						};
+					},
+					getUniqueTriggerID: function () {
+						return '123';
+					}
+				}
+			},
+			devOptions
+		);
+
+		requestFunc({
+			body: {
+				input: {},
+				http: {
+					headers: {},
+					body: '{}'
+				}
+			}
+		})
+
+		.done(
+			function (response) {
+				assert.deepEqual(
+					response,
+					{
+						version: 2,
+						headers: {
+							trigger_deduplication_id: '123'
+						},
+						body: {
+							output: '{}',
+							http: {
+								body: new Buffer(JSON.stringify(returnBody)).toString('base64')
+							}
+						}
+					}
+				);
+
+				done();
+			},
+			function (err) {
+				assert.fail(err);
+				done();
+			}
+		);
+
+	});
+
+	it('should set trigger_deduplication_id when getUniqueTriggerID returns a valid number', function (done) {
+		this.slow(1200);
+
+		var returnBody = { test: 123 };
+
+		var requestFunc = bindTriggerRequest(
+			{
+				request: {
+					reply: function () {
+						return {
+							body: returnBody
+						};
+					},
+					getUniqueTriggerID: function () {
+						return 123;
+					}
+				}
+			},
+			devOptions
+		);
+
+		requestFunc({
+			body: {
+				input: {},
+				http: {
+					headers: {},
+					body: '{}'
+				}
+			}
+		})
+
+		.done(
+			function (response) {
+				assert.deepEqual(
+					response,
+					{
+						version: 2,
+						headers: {
+							trigger_deduplication_id: 123
+						},
+						body: {
+							output: '{}',
+							http: {
+								body: new Buffer(JSON.stringify(returnBody)).toString('base64')
+							}
+						}
+					}
+				);
+
+				done();
+			},
+			function (err) {
+				assert.fail(err);
+				done();
+			}
+		);
+
+	});
+
+	it('should set trigger_deduplication_id when getUniqueTriggerID returns a valid value as a promise', function (done) {
+		this.slow(1200);
+
+		var returnBody = { test: 123 };
+
+		var requestFunc = bindTriggerRequest(
+			{
+				request: {
+					reply: function () {
+						return {
+							body: returnBody
+						};
+					},
+					getUniqueTriggerID: function () {
+						return when.resolve('123');
+					}
+				}
+			},
+			devOptions
+		);
+
+		requestFunc({
+			body: {
+				input: {},
+				http: {
+					headers: {},
+					body: '{}'
+				}
+			}
+		})
+
+		.done(
+			function (response) {
+				assert.deepEqual(
+					response,
+					{
+						version: 2,
+						headers: {
+							trigger_deduplication_id: '123'
+						},
+						body: {
+							output: '{}',
+							http: {
+								body: new Buffer(JSON.stringify(returnBody)).toString('base64')
+							}
+						}
+					}
+				);
+
+				done();
+			},
+			function (err) {
+				assert.fail(err);
+				done();
+			}
+		);
+
+	});
+
+	it('should error when getUniqueTriggerID is an invalid value', function (done) {
+		this.slow(1200);
+
+		var returnBody = { test: 123 };
+
+		var requestFunc = bindTriggerRequest(
+			{
+				request: {
+					reply: function () {
+						return {
+							body: returnBody
+						};
+					},
+					getUniqueTriggerID: function () {
+						return null;
+					}
+				}
+			},
+			devOptions
+		);
+
+		requestFunc({
+			body: {
+				input: {},
+				http: {
+					headers: {},
+					body: '{}'
+				}
+			}
+		})
+
+		.done(
+			function (response) {
+				assert.fail(response);
+				done();
+			},
+			function (err) {
+				assert.deepEqual(
+					{
+						headers: {},
+						body: {
+							code: '#connector_error',
+							message: 'The result of getUniqueTriggerID is not a string or number.',
+							payload: null
+						}
+					},
+					err
+				);
+				done();
+			}
+		);
+
+	});
+
+	it('should error when getUniqueTriggerID rejects', function (done) {
+		this.slow(1200);
+
+		var returnBody = { test: 123 };
+
+		var requestFunc = bindTriggerRequest(
+			{
+				request: {
+					reply: function () {
+						return {
+							body: returnBody
+						};
+					},
+					getUniqueTriggerID: function () {
+						return when.reject('getUniqueTriggerID error');
+					}
+				}
+			},
+			devOptions
+		);
+
+		requestFunc({
+			body: {
+				input: {},
+				http: {
+					headers: {},
+					body: '{}'
+				}
+			}
+		})
+
+		.done(
+			function (response) {
+				assert.fail(response);
+				done();
+			},
+			function (err) {
+				assert.deepEqual(err.body, 'getUniqueTriggerID error');
 				done();
 			}
 		);


### PR DESCRIPTION
- Trigger request - now supports `getUniqueTriggerID` which expects a function and will set `trigger_deduplication_id` field in the `headers` of the JSON payload (not HTTP headers).
- File handling has been refactored to use AWS SDK and drop use of Knox lib.
  - This now means aws.json file does not need to be added, but instead the role can be set in lambda. (However, manual development will still need the aws.json file on local machine, unless environment variables are set up when node-dev is running).