### PR TITLE
CPS-128: test mode operation exposure

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ example-run.js
 example
 exampleTwo
 exampleThree
+exampleTrigger
 exampleArtisan
 exampleArtisanTwo
 artisan-example-run*

--- a/.npmignore
+++ b/.npmignore
@@ -10,8 +10,7 @@ exampleTrigger
 exampleArtisan
 exampleArtisanTwo
 artisan-example-run*
-legacy-example-run*
-legacy-example-schema-export*
+legacy-example*
 exampleSOAP*
 runTest
 
@@ -23,3 +22,6 @@ Gruntfile.js
 # Credentials
 dummycredentials.json
 aws.json
+
+# Other
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -405,22 +405,23 @@ Depends on the `generate-schema` module being installed as a `devDependency` of 
 
 
 ## Testing the connector
+### As a server/exposed function
+Running the connector with `NODE_ENV` set to `development` as an environment variable will spin up a testing HTTP server, to which request to connector operations can be made via a tool like Postman.
 
-Running the connector with `NODE_ENV` set to `development` also spins up a testing HTTP server, which
-you can send sample connector messages too via a tool like Postman.
-
-HTTP requests can be sent to `http://localhost:8989/send/123-def` with a body format like
-
-```
+HTTP requests are sent to `http://localhost:8989/send/123-def` with a body format like:
+```json
 {
   "id": "123-def",
   "header": {
     "message": "[OPERATION NAME]"
   },
   "body": {
-    ...[INPUT PARAMETERS]
+    //...[INPUT PARAMETERS]
   }
 }
 ```
 
 The id `123-def` is used when testing.
+
+### Writing tests
+Generally, sub-operations are not exposed in the `falafel["connector name"]` object. However, if access is needed for when writing test scripts, setting `NODE_ENV` to `test` as an environment variable will add the sub-operations to the `falafel["connector name"]` object.

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ HTTP requests are sent to `http://localhost:8989/send/123-def` with a body forma
     "message": "[OPERATION NAME]"
   },
   "body": {
-    //...[INPUT PARAMETERS]
+    "...[INPUT PARAMETERS]"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -424,4 +424,4 @@ HTTP requests are sent to `http://localhost:8989/send/123-def` with a body forma
 The id `123-def` is used when testing.
 
 ### Writing tests
-Generally, sub-operations like `request.js` and `output.js` are not exposed in the `falafel["connector name"]` object. However, if access is needed for when writing test scripts, setting `NODE_ENV` to `test` as an environment variable will add the sub-operations to the `falafel["connector name"]` object.
+Generally, sub-operations like `request.js` and `output.js` are not exposed in the `falafel['connector name']` object. However, if access is needed for when writing test scripts, setting `NODE_ENV` to `test` as an environment variable will add the sub-operations to the `falafel['connector name']` object.

--- a/README.md
+++ b/README.md
@@ -424,4 +424,4 @@ HTTP requests are sent to `http://localhost:8989/send/123-def` with a body forma
 The id `123-def` is used when testing.
 
 ### Writing tests
-Generally, sub-operations are not exposed in the `falafel["connector name"]` object. However, if access is needed for when writing test scripts, setting `NODE_ENV` to `test` as an environment variable will add the sub-operations to the `falafel["connector name"]` object.
+Generally, sub-operations like `request.js` and `output.js` are not exposed in the `falafel["connector name"]` object. However, if access is needed for when writing test scripts, setting `NODE_ENV` to `test` as an environment variable will add the sub-operations to the `falafel["connector name"]` object.

--- a/exampleTrigger/connectors.json
+++ b/exampleTrigger/connectors.json
@@ -1,0 +1,31 @@
+[
+	{
+		"name": "testtrigger",
+		"title": "Test trigger",
+		"description": "Test trigger to test things in.",
+		"version": "1.0",
+		"tags": [
+			"service"
+		],
+		"icon": {
+			"type": "streamline",
+			"value": "globe-2"
+		},
+		"messages": [
+			{
+				"name": "webhook1",
+				"title": "Test date formatter",
+				"description": "Auto formats dates.",
+				"input_schema": {
+					"type": "object",
+					"properties": {},
+					"required": [],
+					"advanced": [],
+					"$schema": "http://json-schema.org/draft-04/schema#",
+					"additionalProperties": false
+				},
+				"dynamic_output": false
+			}
+		]
+	}
+]

--- a/exampleTrigger/connectors/testtrigger/connector.js
+++ b/exampleTrigger/connectors/testtrigger/connector.js
@@ -1,0 +1,30 @@
+/*
+ * High level basic configuration for the connector.
+ *
+ * Documentation: https://github.com/trayio/falafel#connector-file
+ */
+
+module.exports = {
+
+	// The name of the connector is the folder name
+
+	// The title
+	title: 'Test trigger',
+
+	// The connector description
+	description: 'Test trigger to test things in.',
+
+	// Version of the connector. Updating this will allow users to choose
+	// which connector version they use in advanced settings of the tray UI.
+	version: '1.0',
+
+	// Tags attached to the connector
+	tags: ['service'],
+
+	// Icon of the connector.
+	icon: {
+		type: 'streamline',
+		value: 'globe-2'
+	}
+
+};

--- a/exampleTrigger/connectors/testtrigger/global_model.js
+++ b/exampleTrigger/connectors/testtrigger/global_model.js
@@ -1,0 +1,9 @@
+/*
+* Global connector model config.
+*
+* Documentation: https://github.com/trayio/falafel#global-models
+*/
+
+
+module.exports = {
+};

--- a/exampleTrigger/connectors/testtrigger/global_schema.js
+++ b/exampleTrigger/connectors/testtrigger/global_schema.js
@@ -1,0 +1,10 @@
+/*
+* Global connector schema config.
+*
+* Documentation: https://github.com/trayio/falafel#global-message-schemas
+*/
+
+
+module.exports = {
+
+};

--- a/exampleTrigger/connectors/testtrigger/webhook1/destroy.js
+++ b/exampleTrigger/connectors/testtrigger/webhook1/destroy.js
@@ -1,0 +1,5 @@
+module.exports = function (input) {
+
+	return when.resolve(input);
+
+};

--- a/exampleTrigger/connectors/testtrigger/webhook1/model.js
+++ b/exampleTrigger/connectors/testtrigger/webhook1/model.js
@@ -1,0 +1,5 @@
+module.exports = function (input) {
+
+	return when.resolve(input);
+
+};

--- a/exampleTrigger/connectors/testtrigger/webhook1/request.js
+++ b/exampleTrigger/connectors/testtrigger/webhook1/request.js
@@ -1,0 +1,11 @@
+module.exports = {
+
+	filter: function () {
+		return true;
+	},
+
+	before: function (params, http) {
+		return http.body;
+	}
+
+};

--- a/exampleTrigger/connectors/testtrigger/webhook1/response.js
+++ b/exampleTrigger/connectors/testtrigger/webhook1/response.js
@@ -1,0 +1,3 @@
+module.exports = function (params, http, reply) {
+  return when.resolve(reply);
+}

--- a/exampleTrigger/connectors/testtrigger/webhook1/schema.js
+++ b/exampleTrigger/connectors/testtrigger/webhook1/schema.js
@@ -1,0 +1,13 @@
+module.exports = {
+
+	title: 'Test date formatter',
+
+	description: 'Auto formats dates.',
+
+	input: {
+
+
+
+	}
+
+};

--- a/exampleTrigger/docs.html
+++ b/exampleTrigger/docs.html
@@ -1,0 +1,28 @@
+
+
+<h2>Configuration</h2>
+<table class="table-striped">
+	<tbody>
+		<tr>
+			<th style="width: 25%">
+				Operation
+			</th>
+			<th>
+				Description
+			</th>
+		</tr>
+
+		
+		<tr>
+			<td>
+				<em>Test date formatter</em>
+			</td>
+			<td>
+				Auto formats dates.
+			</td>
+		</tr>
+		
+	</tbody>
+</table>
+
+

--- a/legacy-example-trigger-run.js
+++ b/legacy-example-trigger-run.js
@@ -1,0 +1,10 @@
+
+
+var Falafel = require('./');
+
+// Start the server
+var apptalk = new Falafel().wrap({
+	directory: __dirname+'/exampleTrigger'
+});
+
+exports.apptalk = apptalk;

--- a/lib/bindConnectors/bindMessageHooks.js
+++ b/lib/bindConnectors/bindMessageHooks.js
@@ -50,7 +50,7 @@ module.exports = function (config, options) {
 			if (_.isFunction(message.request) || _.isObject(message.request)) {
 				var requestOpName = message.name + '_request';
 				messageHooks[requestOpName] = bindTriggerRequest(message, options);
-				if (process.env.NODE_ENV === 'test') {
+				if (options.test) {
 					falafel[connectorName][formatOperationName(requestOpName)] = messageHooks[requestOpName];
 				}
 			}
@@ -58,7 +58,7 @@ module.exports = function (config, options) {
 			if (_.isFunction(message.response)) {
 				var responseOpName = message.name + '_response';
 				messageHooks[responseOpName] = bindTriggerResponse(message, options);
-				if (process.env.NODE_ENV === 'test') {
+				if (options.test) {
 					falafel[connectorName][formatOperationName(responseOpName)] = messageHooks[responseOpName];
 				}
 			}
@@ -66,7 +66,7 @@ module.exports = function (config, options) {
 			if (_.isFunction(message.dynamicOutput)) {
 				var dynamicOutputOpName = message.name + '_output_schema';
 				messageHooks[dynamicOutputOpName] = bindDynamicOutput(message, options);
-				if (process.env.NODE_ENV === 'test') {
+				if (options.test) {
 					falafel[connectorName][formatOperationName(dynamicOutputOpName)] = messageHooks[dynamicOutputOpName];
 				}
 			}
@@ -74,6 +74,8 @@ module.exports = function (config, options) {
 		});
 
 	});
+
+	console.log(_.keys(falafel[camelCase(config[0].name)]));
 
 	return messageHooks;
 

--- a/lib/bindConnectors/bindMessageHooks.js
+++ b/lib/bindConnectors/bindMessageHooks.js
@@ -1,10 +1,20 @@
 var Threadneedle 		= require('@trayio/threadneedle');
 var _ 					= require('lodash');
+var camelCase        = require('mout/string/camelCase');
+
 var bindMessage         = require('./bindMessage');
 var bindDynamicOutput   = require('./bindDynamicOutput');
 var bindTriggerRequest  = require('./bindTriggerRequest');
 var bindTriggerResponse = require('./bindTriggerResponse');
 
+function formatOperationName (name) {
+	var methodName = camelCase(name);
+	//camelCasing loses the hash, so add it back if it was in the original name
+	if (name[0] === '#') {
+		methodName = '#' + methodName;
+	}
+	return methodName;
+}
 
 module.exports = function (config, options) {
 
@@ -17,8 +27,8 @@ module.exports = function (config, options) {
 	// have a conflict in namings.
 	_.each(config, function (connectorConfig) {
 
-		// console.log('Binding connector:', connectorConfig.name);
-		
+		var connectorName = camelCase(connectorConfig.name);
+
 		// Declare threadneedle global config for the connector
 		var threadneedle = new Threadneedle(connectorConfig.globalModel.soap || false);
 		threadneedle.global(connectorConfig.globalModel);
@@ -38,22 +48,32 @@ module.exports = function (config, options) {
 			}
 
 			if (_.isFunction(message.request) || _.isObject(message.request)) {
-				messageHooks[message.name+'_request'] = bindTriggerRequest(message, options);
+				var requestOpName = message.name + '_request';
+				messageHooks[requestOpName] = bindTriggerRequest(message, options);
+				if (process.env.NODE_ENV === 'test') {
+					falafel[connectorName][formatOperationName(requestOpName)] = messageHooks[requestOpName];
+				}
 			}
 
 			if (_.isFunction(message.response)) {
-				messageHooks[message.name+'_response'] = bindTriggerResponse(message, options);
+				var responseOpName = message.name + '_response';
+				messageHooks[responseOpName] = bindTriggerResponse(message, options);
+				if (process.env.NODE_ENV === 'test') {
+					falafel[connectorName][formatOperationName(responseOpName)] = messageHooks[responseOpName];
+				}
 			}
 
 			if (_.isFunction(message.dynamicOutput)) {
-				messageHooks[message.name + '_output_schema'] = bindDynamicOutput(message, options);
+				var dynamicOutputOpName = message.name + '_output_schema';
+				messageHooks[dynamicOutputOpName] = bindDynamicOutput(message, options);
+				if (process.env.NODE_ENV === 'test') {
+					falafel[connectorName][formatOperationName(dynamicOutputOpName)] = messageHooks[dynamicOutputOpName];
+				}
 			}
 
 		});
 
-
 	});
-
 
 	return messageHooks;
 

--- a/lib/bindConnectors/bindMessageHooks.js
+++ b/lib/bindConnectors/bindMessageHooks.js
@@ -75,8 +75,6 @@ module.exports = function (config, options) {
 
 	});
 
-	console.log(_.keys(falafel[camelCase(config[0].name)]));
-
 	return messageHooks;
 
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,8 +71,16 @@ var Falafel = function () {
 
 
 			// Set the `dev` flag based on the environment variable
-			if (_.isUndefined(options.dev) && (process.env.NODE_ENV === 'development')) {
-				options.dev = true;
+			if (_.isUndefined(options.dev)) {
+				switch (process.env.NODE_ENV) {
+					case 'development':
+						options.dev = true;
+						break;
+					case 'test':
+						options.test = true;
+						break;
+				}
+
 			}
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/bindConnectors/index.js
+++ b/test/bindConnectors/index.js
@@ -240,8 +240,6 @@ describe('#bindConnectors', function () {
 
 		var boundTriggers = bindConnectors(triggerConfig, { test: true });
 
-		// console.log(require('util').inspect(falafel['testTrigger']['webhookRequest'].toString(), { depth: null }));
-
 		falafel['testTrigger']['webhookRequest']({
 			id: 'testID',
 			header: {


### PR DESCRIPTION
If `NODE_ENV` is set to `test` falafel will now add sub-operations to the `falafel["connector name"]` object.

The main file to look at is `bindMessageHooks.js`