### PR TITLE
CPS-184: rawHttpRequest validate body

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         'mocha': true,
     },
     'parserOptions': {
-        'ecmaVersion': 2017
+        'ecmaVersion': 2018
     },
     'extends': 'eslint:recommended',
     'globals': {

--- a/lib/bindUtils/index.js
+++ b/lib/bindUtils/index.js
@@ -14,12 +14,14 @@ function setupProtectedServiceUtils () {
 
 const validateBody = require('../rawHttpRequest/validateBody');
 const processBody = require('../rawHttpRequest/processBody');
+const validateAndProcessBody = require('../rawHttpRequest/validateAndProcessBody');
 const validateUrlInput = require('../rawHttpRequest/validateUrlInput');
 const formatOutput = require('../rawHttpRequest/formatOutput');
 function setupRawHttpRequestUtils () {
 	falafel.utils.rawHttpRequest = {
 		validateBody,
 		processBody,
+		validateAndProcessBody,
 		validateUrlInput,
 		formatOutput
 	};

--- a/lib/bindUtils/index.js
+++ b/lib/bindUtils/index.js
@@ -12,13 +12,15 @@ function setupProtectedServiceUtils () {
 	};
 }
 
+const validateBody = require('../rawHttpRequest/validateBody');
 const processBody = require('../rawHttpRequest/processBody');
 const validateUrlInput = require('../rawHttpRequest/validateUrlInput');
 const formatOutput = require('../rawHttpRequest/formatOutput');
 function setupRawHttpRequestUtils () {
 	falafel.utils.rawHttpRequest = {
-		validateUrlInput,
+		validateBody,
 		processBody,
+		validateUrlInput,
 		formatOutput
 	};
 }

--- a/lib/rawHttpRequest/rawHttpRequestModel.js
+++ b/lib/rawHttpRequest/rawHttpRequestModel.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 
+const validateBody = require('./validateBody.js');
 const processBody = require('./processBody.js');
 const validateUrlInput = require('./validateUrlInput.js');
 const validateRequestAgainstWhitelistedUrls = require('../protectedService/validateRequestAgainstWhitelistedUrls.js');
@@ -19,12 +20,14 @@ module.exports = {
 
 		validateUrlInput(params); //Validate `endpoint` and `full_url`
 
-		return processBody(params.body)
-		.then((body) => {
-			params.processedBody = body;
-			return params;
-		});
-
+		if (validateBody(params)) {
+			return processBody(params.body)
+			.then((body) => {
+				params.processedBody = body;
+				return params;
+			});
+		} //else params.processedBody = undefined; This is the case by default.
+		
 	},
 
 	method: '{{method}}',

--- a/lib/rawHttpRequest/rawHttpRequestModel.js
+++ b/lib/rawHttpRequest/rawHttpRequestModel.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 
-const validateBody = require('./validateBody.js');
-const processBody = require('./processBody.js');
+const validateAndProcessBody = require('./validateAndProcessBody.js');
 const validateUrlInput = require('./validateUrlInput.js');
 const validateRequestAgainstWhitelistedUrls = require('../protectedService/validateRequestAgainstWhitelistedUrls.js');
 const formatOutput = require('./formatOutput.js');
@@ -20,14 +19,8 @@ module.exports = {
 
 		validateUrlInput(params); //Validate `endpoint` and `full_url`
 
-		if (validateBody(params)) {
-			return processBody(params.body)
-			.then((body) => {
-				params.processedBody = body;
-				return params;
-			});
-		} //else params.processedBody = undefined; This is the case by default.
-		
+		return validateAndProcessBody(params);
+
 	},
 
 	method: '{{method}}',

--- a/lib/rawHttpRequest/validateAndProcessBody.js
+++ b/lib/rawHttpRequest/validateAndProcessBody.js
@@ -1,0 +1,12 @@
+const validateBody = require('./validateBody.js');
+const processBody = require('./processBody.js');
+
+module.exports = function (params) {
+	if (validateBody(params)) {
+		return processBody(params.body)
+		.then((body) => {
+			params.processedBody = body;
+			return params;
+		});
+	} //else params.processedBody = undefined; This is the case by default.
+};

--- a/lib/rawHttpRequest/validateAndProcessBody.js
+++ b/lib/rawHttpRequest/validateAndProcessBody.js
@@ -1,7 +1,7 @@
 const validateBody = require('./validateBody.js');
 const processBody = require('./processBody.js');
 
-module.exports = function (params) {
+module.exports = async function (params) {
 	if (validateBody(params)) {
 		return processBody(params.body)
 		.then((body) => {

--- a/lib/rawHttpRequest/validateBody.js
+++ b/lib/rawHttpRequest/validateBody.js
@@ -1,4 +1,12 @@
+const keyError = new Error('The `body` object must contain only one of the following valid properties: `raw`, `form_urlencoded`, `form_data`, `binary`, or `none`.');
+
 function checkForValidBodyKey (body) {
+	const bodyKeys = _.keysIn(body);
+
+	if (bodyKeys.length !== 1) {
+		throw keyError;
+	}
+
 	switch (_.keysIn(body)[0]) {
 		case 'raw':
 		case 'form_urlencoded':
@@ -7,7 +15,7 @@ function checkForValidBodyKey (body) {
 		case 'none':
 			break;
 		default:
-			throw new Error('The `body` object must contain only one of the following valid properties: `raw`, `form_urlencoded`, `form_data`, `binary`, or `none`.');
+			throw keyError;
 	}
 }
 

--- a/lib/rawHttpRequest/validateBody.js
+++ b/lib/rawHttpRequest/validateBody.js
@@ -1,3 +1,16 @@
+function checkForValidBodyKey (body) {
+	switch (_.keysIn(body)[0]) {
+		case 'raw':
+		case 'form_urlencoded':
+		case 'form_data':
+		case 'binary':
+		case 'none':
+			break;
+		default:
+			throw new Error('The `body` object must contain only one of the following valid properties: `raw`, `form_urlencoded`, `form_data`, `binary`, or `none`.');
+	}
+}
+
 module.exports = function ({ method, body }) {
 
 	switch (method.toLowerCase()) {
@@ -10,6 +23,7 @@ module.exports = function ({ method, body }) {
 			if (_.isUndefined(body)) {
 				throw new Error('`body` must be supplied. Please select a valid "Body Type".');
 			} else {
+				checkForValidBodyKey(body);
 				return true;
 			}
 		}

--- a/lib/rawHttpRequest/validateBody.js
+++ b/lib/rawHttpRequest/validateBody.js
@@ -1,0 +1,18 @@
+module.exports = function ({ method, body }) {
+
+	switch (method.toLowerCase()) {
+		case 'get':
+		case 'head':
+		case 'options':
+			//No body should be processed for these HTTP verbs.
+			return false;
+		default: {
+			if (_.isUndefined(body)) {
+				throw new Error('`body` must be supplied. Please select a valid "Body Type".');
+			} else {
+				return true;
+			}
+		}
+	}
+
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {

--- a/rawHttpRequest.md
+++ b/rawHttpRequest.md
@@ -85,15 +85,20 @@ By default, the global schema of the connector is not inherited, as it is assume
 ## Utils
 The Raw HTTP Request model utilises some functions which are also exposed via `falafel.utils.rawHttpRequest`, so that `rawHttpRequest.js` has access to these when custom configuration needs to be supported.
 
-### validateUrlInput
-[*falafel.utils.rawHttpRequest.validateUrlInput*](lib/rawHttpRequest/validateUrlInput.js)
+### validateBody
+[*falafel.utils.rawHttpRequest.validateBody*](lib/rawHttpRequest/validateBody.js)
 
-This function accepts the `params` object, and validate the `url` property. If the `endpoint` is provided, the function will ensure it does not start with `http://` or `https://`. Conversely, if `full_url` is provided, the function will ensure the string starts with `http://` or `https://`. If validation is not satisfied, an error will be thrown.
+This function accepts the whole `params` and validates against `method` and `body` properties. If `method` is `GET`, `HEAD`, or `OPTIONS`, the function returns `false`, indicating no body should be processed. For any other HTTP verb, if `body` is `undefined`, an error will be thrown indicating that `body` is required; else, `true` will be returned to indicate processing of `body` is required.
 
 ### processBody
 [*falafel.utils.rawHttpRequest.processBody*](lib/rawHttpRequest/processBody.js)
 
 This ASYNC function requires the `body` property to be provided from `params`. The function will process the `body`'s specified oneOf configuration into the required format for Threadneedle. This includes downloading files for `form_data`.
+
+### validateUrlInput
+[*falafel.utils.rawHttpRequest.validateUrlInput*](lib/rawHttpRequest/validateUrlInput.js)
+
+This function accepts the `params` object, and validate the `url` property. If the `endpoint` is provided, the function will ensure it does not start with `http://` or `https://`. Conversely, if `full_url` is provided, the function will ensure the string starts with `http://` or `https://`. If validation is not satisfied, an error will be thrown.
 
 ### formatOutput
 [*falafel.utils.rawHttpRequest.formatOutput*](lib/rawHttpRequest/formatOutput.js)

--- a/rawHttpRequest.md
+++ b/rawHttpRequest.md
@@ -95,6 +95,11 @@ This function accepts the whole `params` and validates against `method` and `bod
 
 This ASYNC function requires the `body` property to be provided from `params`. The function will process the `body`'s specified oneOf configuration into the required format for Threadneedle. This includes downloading files for `form_data`.
 
+### validateAndProcessBody
+[*falafel.utils.rawHttpRequest.validateAndProcessBody*](lib/rawHttpRequest/validateAndProcessBody.js)
+
+This ASYNC function performs `validateBody` and `processBody`. `params` is the only argument, and the function returns `params` if modified, else `undefined`.
+
 ### validateUrlInput
 [*falafel.utils.rawHttpRequest.validateUrlInput*](lib/rawHttpRequest/validateUrlInput.js)
 

--- a/test/rawHttpRequest/validateBody_test.js
+++ b/test/rawHttpRequest/validateBody_test.js
@@ -1,0 +1,238 @@
+const assert = require('assert');
+
+const _ = require('lodash');
+
+const validateBody = require('../../lib/rawHttpRequest/validateBody.js');
+
+describe.only('validateBody', () => {
+
+	it('should be a function', () => {
+		assert(_.isFunction(validateBody));
+	});
+
+	it('should return false for GET, HEAD, and OPTIONS', () => {
+
+		const sampleParams = {
+			body: {
+				raw: 'something'
+			}
+		};
+
+		const validationResult = validateBody({
+			method: 'get',
+			...sampleParams
+		});
+
+		assert.deepEqual(validationResult, false);
+
+		const validationResult2 = validateBody({
+			method: 'head',
+			...sampleParams
+		});
+
+		assert.deepEqual(validationResult2, false);
+
+		const validationResult3 = validateBody({
+			method: 'options',
+			...sampleParams
+		});
+
+		assert.deepEqual(validationResult3, false);
+
+	});
+
+	it('should return true for POST, PUT, PATCH, and DELETE', () => {
+
+		const sampleParams = {
+			body: {
+				raw: 'something'
+			}
+		};
+
+		const validationResult = validateBody({
+			method: 'post',
+			...sampleParams
+		});
+
+		assert.deepEqual(validationResult, true);
+
+		const validationResult2 = validateBody({
+			method: 'put',
+			...sampleParams
+		});
+
+		assert.deepEqual(validationResult2, true);
+
+		const validationResult3 = validateBody({
+			method: 'patch',
+			...sampleParams
+		});
+
+		assert.deepEqual(validationResult3, true);
+
+		const validationResult4 = validateBody({
+			method: 'delete',
+			...sampleParams
+		});
+
+		assert.deepEqual(validationResult4, true);
+
+	});
+
+	describe('should error when body is not provided', () => {
+
+		const errMessage = '`body` must be supplied. Please select a valid "Body Type".';
+
+		it('post', () => {
+			let validationResult;
+			try {
+				validationResult = validateBody({
+					method: 'post'
+				});
+			} catch (validationError) {
+				assert(_.includes(validationError.message, errMessage));
+				return;
+			}
+			assert.fail(validationResult);
+		});
+
+		it('put', () => {
+			let validationResult;
+			try {
+				validationResult = validateBody({
+					method: 'put'
+				});
+			} catch (validationError) {
+				assert(_.includes(validationError.message, errMessage));
+				return;
+			}
+			assert.fail(validationResult);
+		});
+
+		it('put', () => {
+			let validationResult;
+			try {
+				validationResult = validateBody({
+					method: 'put'
+				});
+			} catch (validationError) {
+				assert(_.includes(validationError.message, errMessage));
+				return;
+			}
+			assert.fail(validationResult);
+		});
+
+		it('delete', () => {
+			let validationResult;
+			try {
+				validationResult = validateBody({
+					method: 'delete'
+				});
+			} catch (validationError) {
+				assert(_.includes(validationError.message, errMessage));
+				return;
+			}
+			assert.fail(validationResult);
+		});
+
+	});
+
+	describe('should return true for valid body key', () => {
+
+		it('raw', () => {
+			const validationResult = validateBody({
+				method: 'post',
+				body: {
+					raw: 'something'
+				}
+			});
+
+			assert.deepEqual(validationResult, true);
+		});
+
+		it('form_urlencoded', () => {
+			const validationResult = validateBody({
+				method: 'post',
+				body: {
+					form_urlencoded: {}
+				}
+			});
+
+			assert.deepEqual(validationResult, true);
+		});
+
+		it('form_data', () => {
+			const validationResult = validateBody({
+				method: 'post',
+				body: {
+					form_data: {}
+				}
+			});
+
+			assert.deepEqual(validationResult, true);
+		});
+
+		it('binary', () => {
+			const validationResult = validateBody({
+				method: 'post',
+				body: {
+					binary: {
+						//file object
+					}
+				}
+			});
+
+			assert.deepEqual(validationResult, true);
+		});
+
+		it('none', () => {
+			const validationResult = validateBody({
+				method: 'post',
+				body: {
+					none: null
+				}
+			});
+
+			assert.deepEqual(validationResult, true);
+		});
+
+	});
+
+	describe('should error when body is not a valid object', () => {
+
+		const errMessage = 'The `body` object must contain only one of the following valid properties: `raw`, `form_urlencoded`, `form_data`, `binary`, or `none`.';
+
+		it('more than 1 key', () => {
+			let validationResult;
+			try {
+				validationResult = validateBody({
+					method: 'post',
+					body: {
+						raw: 'hello world',
+						test: '123'
+					}
+				});
+			} catch (validationError) {
+				assert(_.includes(validationError.message, errMessage));
+				return;
+			}
+			assert.fail(validationResult);
+		});
+
+		it('invalid body', () => {
+			let validationResult;
+			try {
+				validationResult = validateBody({
+					method: 'put',
+					body: 'something'
+				});
+			} catch (validationError) {
+				assert(_.includes(validationError.message, errMessage));
+				return;
+			}
+			assert.fail(validationResult);
+		});
+
+	});
+
+});


### PR DESCRIPTION
- Added logic to validate body.
- Added logic to process body only if not GET, HEAD, or OPTIONS.
- Updated rawHttpRequest doc with more utils