### PR TITLE
CPS-183: raw http request options processing

### DIFF
--- a/exampleRawHttpRequest/connectors.json
+++ b/exampleRawHttpRequest/connectors.json
@@ -245,6 +245,34 @@
 							"default": false,
 							"description": "Include raw body in the operation's response",
 							"title": "Include raw body"
+						},
+						"parse_response": {
+							"type": "string",
+							"enum": [
+								{
+									"text": "All",
+									"description": "Automatically parse all content types if possible.",
+									"value": "true"
+								},
+								{
+									"text": "JSON only",
+									"description": "Only parse JSON content, leave other types as text.",
+									"value": "json"
+								},
+								{
+									"text": "XML only",
+									"description": "Only parse XML content, leave other types as text.",
+									"value": "xml"
+								},
+								{
+									"text": "None",
+									"description": "Always return text.",
+									"value": "false"
+								}
+							],
+							"default": "true",
+							"description": "Automatically parse incoming data to Javascript objects if possible",
+							"title": "Parse response"
 						}
 					},
 					"required": [
@@ -253,7 +281,8 @@
 						"include_raw_body"
 					],
 					"advanced": [
-						"include_raw_body"
+						"include_raw_body",
+						"parse_response"
 					],
 					"$schema": "http://json-schema.org/draft-04/schema#",
 					"additionalProperties": false

--- a/lib/bindUtils/index.js
+++ b/lib/bindUtils/index.js
@@ -15,6 +15,7 @@ function setupProtectedServiceUtils () {
 const validateBody = require('../rawHttpRequest/validateBody');
 const processBody = require('../rawHttpRequest/processBody');
 const validateAndProcessBody = require('../rawHttpRequest/validateAndProcessBody');
+const processOptions = require('../rawHttpRequest/processOptions');
 const validateUrlInput = require('../rawHttpRequest/validateUrlInput');
 const formatOutput = require('../rawHttpRequest/formatOutput');
 function setupRawHttpRequestUtils () {
@@ -22,6 +23,7 @@ function setupRawHttpRequestUtils () {
 		validateBody,
 		processBody,
 		validateAndProcessBody,
+		processOptions,
 		validateUrlInput,
 		formatOutput
 	};

--- a/lib/rawHttpRequest/convertArrayFormatToObject.js
+++ b/lib/rawHttpRequest/convertArrayFormatToObject.js
@@ -1,0 +1,5 @@
+module.exports = function convertArrayFormatToObject (targetArray) {
+	return _.reduce(targetArray, (acc, { key, value }) => {
+		return ( acc[key] = value, acc );
+	}, {});
+};

--- a/lib/rawHttpRequest/convertArrayFormatToObject.js
+++ b/lib/rawHttpRequest/convertArrayFormatToObject.js
@@ -1,4 +1,4 @@
-module.exports = function convertArrayFormatToObject (targetArray) {
+module.exports = function (targetArray) {
 	return _.reduce(targetArray, (acc, { key, value }) => {
 		return ( acc[key] = value, acc );
 	}, {});

--- a/lib/rawHttpRequest/getContentType.js
+++ b/lib/rawHttpRequest/getContentType.js
@@ -1,0 +1,14 @@
+module.exports = function (bodyType, body) {
+	switch (bodyType) {
+		case 'raw':
+			return ( _.isObject(body) ? 'application/json' : 'text/plain' );
+		case 'form_data':
+			return 'multipart/form-data';
+		case 'form_urlencoded':
+			return 'application/x-www-form-urlencoded';
+		case 'binary':
+			return 'text/plain';
+		default:
+			return undefined;
+	}
+};

--- a/lib/rawHttpRequest/getContentTypeFromBody.js
+++ b/lib/rawHttpRequest/getContentTypeFromBody.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 module.exports = function (bodyType, body) {
 	switch (bodyType) {
 		case 'raw':

--- a/lib/rawHttpRequest/processOptions.js
+++ b/lib/rawHttpRequest/processOptions.js
@@ -1,0 +1,50 @@
+const getContentType = require('./getContentType.js');
+const convertArrayFormatToObject = require('./convertArrayFormatToObject.js');
+
+module.exports = function (params) {
+
+	const { processedBody, parse_response } = params;
+
+	let contentType = undefined,
+		json = true;
+
+	if (!_.isUndefined(processedBody)) {
+		const bodyType = _.keysIn(params.body)[0];
+
+		contentType = getContentType(bodyType, processedBody);
+
+		if (contentType) {
+			if (contentType.includes('application/x-www-form-urlencoded')) {
+				json = false;
+			}
+			if (contentType.includes('text/plain')) {
+				json = false;
+			}
+		} else {
+			json = false;
+		}
+
+	}
+
+	let parse;
+	switch (parse_response) {
+		case 'true':
+			parse = true;
+			break;
+		case 'false':
+			parse = false;
+			break;
+		default:
+			parse = parse_response;
+	}
+
+	const headers = convertArrayFormatToObject(params.headers);
+
+	return {
+		headers,
+		json,
+		parse
+	};
+
+
+};

--- a/lib/rawHttpRequest/processOptions.js
+++ b/lib/rawHttpRequest/processOptions.js
@@ -3,21 +3,27 @@ const convertArrayFormatToObject = require('./convertArrayFormatToObject.js');
 
 module.exports = function (params) {
 
-	const { processedBody } = params;
-
 	let contentType = undefined,
 		json = true;
 
+	/*
+		`processedBody` is set in the operation's `before`, and so dependning on
+		HTTP verb or body contents, will be processed or set to undefined
+	*/
+	const { processedBody } = params;
 	if (!_.isUndefined(processedBody)) {
 		const bodyType = _.keysIn(params.body)[0];
 
 		contentType = getContentTypeFromBody(bodyType, processedBody);
 
 		if (contentType) {
-			if (contentType.includes('application/x-www-form-urlencoded')) {
+			if (contentType === 'multipart/form-data') {
 				json = false;
 			}
-			if (contentType.includes('text/plain')) {
+			if (contentType === 'application/x-www-form-urlencoded') {
+				json = false;
+			}
+			if (contentType === 'text/plain') {
 				json = false;
 			}
 		} else {
@@ -46,7 +52,9 @@ module.exports = function (params) {
 	return {
 		headers,
 		json,
-		parse_response
+		parse_response,
+		//Needed for file processing if form_data
+		multipart: contentType.includes('multipart/form-data')
 	};
 
 

--- a/lib/rawHttpRequest/processOptions.js
+++ b/lib/rawHttpRequest/processOptions.js
@@ -1,9 +1,9 @@
-const getContentType = require('./getContentType.js');
+const getContentTypeFromBody = require('./getContentTypeFromBody.js');
 const convertArrayFormatToObject = require('./convertArrayFormatToObject.js');
 
 module.exports = function (params) {
 
-	const { processedBody, parse_response } = params;
+	const { processedBody } = params;
 
 	let contentType = undefined,
 		json = true;
@@ -11,7 +11,7 @@ module.exports = function (params) {
 	if (!_.isUndefined(processedBody)) {
 		const bodyType = _.keysIn(params.body)[0];
 
-		contentType = getContentType(bodyType, processedBody);
+		contentType = getContentTypeFromBody(bodyType, processedBody);
 
 		if (contentType) {
 			if (contentType.includes('application/x-www-form-urlencoded')) {
@@ -26,24 +26,27 @@ module.exports = function (params) {
 
 	}
 
-	let parse;
+	let { parse_response } = params;
 	switch (parse_response) {
 		case 'true':
-			parse = true;
+			parse_response = true;
 			break;
 		case 'false':
-			parse = false;
+			parse_response = false;
 			break;
-		default:
-			parse = parse_response;
 	}
 
 	const headers = convertArrayFormatToObject(params.headers);
 
+	if (_.isUndefined(headers['Content-Type']) && contentType) {
+		//The naming maintains same format as HTTP client connector
+		headers['Content-Type'] = contentType;
+	}
+
 	return {
 		headers,
 		json,
-		parse
+		parse_response
 	};
 
 

--- a/lib/rawHttpRequest/rawHttpRequestModel.js
+++ b/lib/rawHttpRequest/rawHttpRequestModel.js
@@ -1,15 +1,11 @@
 const _ = require('lodash');
 
+const convertArrayFormatToObject = require('./convertArrayFormatToObject.js');
+const processOptions = require('./processOptions.js');
 const processBody = require('./processBody.js');
 const validateUrlInput = require('./validateUrlInput.js');
 const validateRequestAgainstWhitelistedUrls = require('../protectedService/validateRequestAgainstWhitelistedUrls.js');
 const formatOutput = require('./formatOutput.js');
-
-function convertArrayFormatToObject (targetArray) {
-	return _.reduce(targetArray, (acc, { key, value }) => {
-		return ( acc[key] = value, acc );
-	}, {});
-}
 
 module.exports = {
 
@@ -29,11 +25,7 @@ module.exports = {
 
 	method: '{{method}}',
 
-	options: {
-		headers: ({ headers }) => {
-			return convertArrayFormatToObject(headers);
-		}
-	},
+	options: processOptions,
 
 	url: (params) => {
 

--- a/lib/rawHttpRequest/rawHttpRequestModel.js
+++ b/lib/rawHttpRequest/rawHttpRequestModel.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 
 const convertArrayFormatToObject = require('./convertArrayFormatToObject.js');
+const processOptions = require('./processOptions.js');
 const validateAndProcessBody = require('./validateAndProcessBody.js');
 const validateUrlInput = require('./validateUrlInput.js');
 const validateRequestAgainstWhitelistedUrls = require('../protectedService/validateRequestAgainstWhitelistedUrls.js');

--- a/lib/rawHttpRequest/rawHttpRequestSchema.js
+++ b/lib/rawHttpRequest/rawHttpRequestSchema.js
@@ -202,7 +202,36 @@ module.exports = {
 			required: true,
 			advanced: true,
 			default: false
-		}
+		},
+
+		parse_response: {
+			type: 'string',
+			description: 'Automatically parse incoming data to Javascript objects if possible',
+			enum: [
+				{
+					text: 'All',
+					description: 'Automatically parse all content types if possible.',
+					value: 'true',
+				},
+				{
+					text: 'JSON only',
+					description: 'Only parse JSON content, leave other types as text.',
+					value: 'json',
+				},
+				{
+					text: 'XML only',
+					description: 'Only parse XML content, leave other types as text.',
+					value: 'xml',
+				},
+				{
+					text: 'None',
+					description: 'Always return text.',
+					value: 'false',
+				},
+			],
+			default: 'true',
+			advanced: true,
+		},
 
 	},
 

--- a/lib/rawHttpRequest/validateBody.js
+++ b/lib/rawHttpRequest/validateBody.js
@@ -7,7 +7,7 @@ function checkForValidBodyKey (body) {
 		throw keyError;
 	}
 
-	switch (_.keysIn(body)[0]) {
+	switch (bodyKeys[0]) {
 		case 'raw':
 		case 'form_urlencoded':
 		case 'form_data':

--- a/rawHttpRequest.md
+++ b/rawHttpRequest.md
@@ -100,6 +100,11 @@ This ASYNC function requires the `body` property to be provided from `params`. T
 
 This ASYNC function performs `validateBody` and `processBody`. `params` is the only argument, and the function returns `params` if modified, else `undefined`.
 
+### processOptions
+[*falafel.utils.rawHttpRequest.processOptions*](lib/rawHttpRequest/processOptions.js)
+
+This function requires the `params` object, after `processedBody` has been set (i.e. in the `before`), and returns an `options` object. The content type is evaluated based on the body and type, which is then set in the headers (unless specified), and also used to set both `json` and `multipart` flags for needle.
+
 ### validateUrlInput
 [*falafel.utils.rawHttpRequest.validateUrlInput*](lib/rawHttpRequest/validateUrlInput.js)
 

--- a/test/rawHttpRequest/processOptions_test.js
+++ b/test/rawHttpRequest/processOptions_test.js
@@ -1,0 +1,191 @@
+const assert = require('assert');
+const fs = require('fs');
+const { PassThrough } = require('stream');
+
+const _ = require('lodash');
+
+const processOptions = require('../../lib/rawHttpRequest/processOptions.js');
+
+describe('processOptions', () => {
+
+	it('should be a function', () => {
+		assert(_.isFunction(processOptions));
+	});
+
+	it('should set headers', () => {
+
+		const sampleParams = {
+			body: {
+				raw: 'Hello world',
+			},
+			processedBody: 'Hello world',
+			headers: [
+				{
+					key: 'Authorization',
+					value: 'Bearer test'
+				}
+			]
+		};
+
+		const processedOptions = processOptions(sampleParams);
+
+		assert.deepEqual(
+			processedOptions.headers,
+			{
+				Authorization: 'Bearer test',
+				'Content-Type': 'text/plain'
+			}
+		);
+
+	});
+
+	describe('should process content type based on body, and set json and multipart flags', async () => {
+
+		it('raw - string', () => {
+
+			const processedOptions = processOptions({
+				body: {
+					raw: 'Hello world',
+				},
+				processedBody: 'Hello world'
+			});
+
+			assert.deepEqual(
+				processedOptions.headers,
+				{
+					'Content-Type': 'text/plain'
+				}
+			);
+			assert.strictEqual(processedOptions.json, false);
+			assert.strictEqual(processedOptions.multipart, false);
+
+		});
+
+		it('raw - object', () => {
+
+			const processedOptions = processOptions({
+				body: {
+					raw: {
+						test: 'Hello world'
+					},
+				},
+				processedBody: {
+					test: 'Hello world'
+				}
+			});
+
+			assert.deepEqual(
+				processedOptions.headers,
+				{
+					'Content-Type': 'application/json'
+				}
+			);
+			assert.strictEqual(processedOptions.json, true);
+			assert.strictEqual(processedOptions.multipart, false);
+
+		});
+
+		it('form_data', () => {
+
+			const processedOptions = processOptions({
+				body: {
+					form_data: {
+						test: 'Hello world'
+					},
+				},
+				processedBody: {
+					test: 'Hello world'
+				}
+			});
+
+			assert.deepEqual(
+				processedOptions.headers,
+				{
+					'Content-Type': 'multipart/form-data'
+				}
+			);
+			assert.strictEqual(processedOptions.json, false);
+			assert.strictEqual(processedOptions.multipart, true);
+
+		});
+
+		it('form_urlencoded', () => {
+
+			const processedOptions = processOptions({
+				body: {
+					form_urlencoded: {
+						test: 'Hello world'
+					},
+				},
+				processedBody: {
+					test: 'Hello world'
+				}
+			});
+
+			assert.deepEqual(
+				processedOptions.headers,
+				{
+					'Content-Type': 'application/x-www-form-urlencoded'
+				}
+			);
+			assert.strictEqual(processedOptions.json, false);
+			assert.strictEqual(processedOptions.multipart, false);
+
+		});
+
+		it('binary', () => {
+
+			const passThrough = new PassThrough();
+			passThrough.end('Hello World');
+
+			const processedOptions = processOptions({
+				body: {
+					binary: {
+						//file object
+					},
+				},
+				processedBody: passThrough
+			});
+
+			assert.deepEqual(
+				processedOptions.headers,
+				{
+					'Content-Type': 'text/plain'
+				}
+			);
+			assert.strictEqual(processedOptions.json, false);
+			assert.strictEqual(processedOptions.multipart, false);
+
+		});
+
+	});
+
+	it('should use user defined Content-Type of processed value', () => {
+
+		const sampleParams = {
+			body: {
+				raw: {
+					test: 'Hello world'
+				},
+			},
+			processedBody: 'Hello world',
+			headers: [
+				{
+					key: 'Content-Type',
+					value: 'application/vnd+json'
+				}
+			]
+		};
+
+		const processedOptions = processOptions(sampleParams);
+
+		assert.deepEqual(
+			processedOptions.headers,
+			{
+				'Content-Type': 'application/vnd+json'
+			}
+		);
+
+	});
+
+});

--- a/test/rawHttpRequest/processOptions_test.js
+++ b/test/rawHttpRequest/processOptions_test.js
@@ -168,7 +168,9 @@ describe('processOptions', () => {
 					test: 'Hello world'
 				},
 			},
-			processedBody: 'Hello world',
+			processedBody: {
+				test: 'Hello world'
+			},
 			headers: [
 				{
 					key: 'Content-Type',
@@ -185,6 +187,71 @@ describe('processOptions', () => {
 				'Content-Type': 'application/vnd+json'
 			}
 		);
+
+	});
+
+	describe('should set parse_response correctly', () => {
+
+		it('true', () => {
+			const sampleParams = {
+				body: {
+					raw: 'Hello world',
+				},
+				processedBody: 'Hello world',
+				headers: [],
+				parse_response: 'true'
+			};
+
+			const processedOptions = processOptions(sampleParams);
+
+			assert.strictEqual(processedOptions.parse_response,	true);
+		});
+
+		it('json', () => {
+			const sampleParams = {
+				body: {
+					raw: 'Hello world',
+				},
+				processedBody: 'Hello world',
+				headers: [],
+				parse_response: 'json'
+			};
+
+			const processedOptions = processOptions(sampleParams);
+
+			assert.strictEqual(processedOptions.parse_response,	'json');
+		});
+
+		it('xml', () => {
+			const sampleParams = {
+				body: {
+					raw: 'Hello world',
+				},
+				processedBody: 'Hello world',
+				headers: [],
+				parse_response: 'xml'
+			};
+
+			const processedOptions = processOptions(sampleParams);
+
+			assert.strictEqual(processedOptions.parse_response,	'xml');
+		});
+
+		it('false', () => {
+			const sampleParams = {
+				body: {
+					raw: 'Hello world',
+				},
+				processedBody: 'Hello world',
+				headers: [],
+				parse_response: 'false'
+			};
+
+			const processedOptions = processOptions(sampleParams);
+
+			assert.strictEqual(processedOptions.parse_response,	false);
+		});
+
 
 	});
 

--- a/test/rawHttpRequest/validateBody_test.js
+++ b/test/rawHttpRequest/validateBody_test.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 const validateBody = require('../../lib/rawHttpRequest/validateBody.js');
 
-describe.only('validateBody', () => {
+describe('validateBody', () => {
 
 	it('should be a function', () => {
 		assert(_.isFunction(validateBody));


### PR DESCRIPTION
- Smart options processing has been added which will evaluate body and try to set content type header (unless specified), along with json and multipart flags for needle.
- processOptions added to utils with doc update
- Parsing options has also been set in both schema and processOptions.