### PR TITLE
CPS-193: file handling max ram variable

### DIFF
--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -16,10 +16,13 @@ const REGION = 'us-west-2',
 	BUCKET = 'workflow-file-uploads',
 	DEV_BUCKET = 'workflow-file-uploads-dev';
 
-const UPLOAD_MIN_SIZE = 1024 * 1024 * 8, //8MB
-	MAX_RAM = 1024 * 1024 * ( process.env['AWS_LAMBDA_FUNCTION_MEMORY_SIZE'] || 128 ); //128MB default
+const ALLOCATED_RAM = process.env['AWS_LAMBDA_FUNCTION_MEMORY_SIZE'] || process.env['CONNECTOR_MAX_ALLOCATED_RAM_MB'];
+const availableRAM = ( ALLOCATED_RAM ? _.parseInt(ALLOCATED_RAM) : 128 ); //128MB default
 
-let TARGET_SIZE = MAX_RAM / 16;
+const UPLOAD_MIN_SIZE = 1024 * 1024 * 8, //8MB
+	MAX_RAM = 1024 * 1024 * availableRAM;
+
+let TARGET_SIZE = _.floor(MAX_RAM / 16); //128 / 16 = 8 (which is UPLOAD_MIN_SIZE)
 TARGET_SIZE = ( TARGET_SIZE < UPLOAD_MIN_SIZE ? UPLOAD_MIN_SIZE : TARGET_SIZE );
 
 function logError (errorName, error) {

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -25,6 +25,12 @@ const UPLOAD_MIN_SIZE = 1024 * 1024 * 8, //8MB
 let TARGET_SIZE = _.floor(MAX_RAM / 16); //128 / 16 = 8 (which is UPLOAD_MIN_SIZE)
 TARGET_SIZE = ( TARGET_SIZE < UPLOAD_MIN_SIZE ? UPLOAD_MIN_SIZE : TARGET_SIZE );
 
+const DEFAULT_UPLOAD_OPTIONS = {
+	// 8MB * 4 parallel = upto 32MB/s RAM usage
+	partSize: TARGET_SIZE,
+	queueSize: 4
+};
+
 function logError (errorName, error) {
 	// eslint-disable-next-line no-console
 	console.error(errorName, util.inspect(error, { depth: null }));
@@ -214,11 +220,8 @@ module.exports = function (options) {
 				ContentType: mimeType
 			};
 
-			const uploadOptions = {
-				partSize: UPLOAD_MIN_SIZE, //default 8MB parts
-				queueSize: 4 //default 4 parallel uploads
-			};
-			if (!_.isUndefined(params.length)) {
+			const uploadOptions = DEFAULT_UPLOAD_OPTIONS;
+			if (!_.isUndefined(params.length)) { //i.e. if file length is specified
 				const fileSize = uploadParams.ContentLength = params.length;
 
 				if (fileSize > UPLOAD_MIN_SIZE) {
@@ -230,6 +233,8 @@ module.exports = function (options) {
 				}
 
 			}
+
+
 			// eslint-disable-next-line no-console
 			console.log('Falafel upload', JSON.stringify(uploadOptions));
 			const passThroughStream = new PassThrough({ highWaterMark: uploadOptions.partSize });

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -26,9 +26,9 @@ let TARGET_SIZE = _.floor(MAX_RAM / 16); //128 / 16 = 8 (which is UPLOAD_MIN_SIZ
 TARGET_SIZE = ( TARGET_SIZE < UPLOAD_MIN_SIZE ? UPLOAD_MIN_SIZE : TARGET_SIZE );
 
 const DEFAULT_UPLOAD_OPTIONS = {
-	// 8MB * 4 parallel = upto 32MB/s RAM usage
+	// 8MB (minimum) * 4 parallel = upto 32MB/s RAM usage
 	partSize: TARGET_SIZE,
-	queueSize: 4
+	queueSize: 4 //Ensures at least up to 1/4 of the RAM is utilised
 };
 
 function logError (errorName, error) {
@@ -140,6 +140,7 @@ module.exports = function (options) {
 
 				const twentyFourHourPeriod = moment().add(1, 'days');
 
+
 				s3.getSignedUrl(
 					'getObject',
 					{
@@ -220,20 +221,35 @@ module.exports = function (options) {
 				ContentType: mimeType
 			};
 
+			/*
+				TODO: in the future, replace s3.upload with manual multipart
+				uploading using the AWS SDK. This should be done with a custom
+				Async Queue so that the partSize and queueSize can be modified
+				to scale over time and when certain data size thresholds are
+				met, all the way to a maximum partSize and queueSize. This means
+				for large files for which length is unknown, partSize and
+				queueSize can dynamically increase until maximum.
+			*/
 			const uploadOptions = DEFAULT_UPLOAD_OPTIONS;
-			if (!_.isUndefined(params.length)) { //i.e. if file length is specified
-				const fileSize = uploadParams.ContentLength = params.length;
-
-				if (fileSize > UPLOAD_MIN_SIZE) {
-					uploadOptions.partSize = TARGET_SIZE;
-					if (fileSize > (TARGET_SIZE * 8)) {
-						//This should use up half the available RAM (queueSize * partSize)
-						uploadOptions.queueSize = 8;
-					}
+			if (_.isUndefined(params.length)) { //i.e. if file length is not specified
+				/*
+					Since file size is not known, if `CONNECTOR_MAX_ALLOCATED_RAM_MB`
+					is provided, increase queueSize so that up to 3/4 is used
+				*/
+				if (process.env['CONNECTOR_MAX_ALLOCATED_RAM_MB']) {
+					uploadOptions.queueSize = 12;
 				}
-
+			} else { //i.e. if file length is specified
+				const fileSize = uploadParams.ContentLength = params.length;
+				/*
+					If file size is over half the available RAM, update
+					queueSize so that up to 3/4 RAM is used
+					(queueSize * partSize)
+				*/
+				if (fileSize > TARGET_SIZE  && fileSize > (TARGET_SIZE * 8)) {
+					uploadOptions.queueSize = 12;
+				}
 			}
-
 
 			// eslint-disable-next-line no-console
 			console.log('Falafel upload', JSON.stringify(uploadOptions));

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -22,7 +22,13 @@ const availableRAM = ( ALLOCATED_RAM ? _.parseInt(ALLOCATED_RAM) : 128 ); //128M
 const UPLOAD_MIN_SIZE = 1024 * 1024 * 8, //8MB
 	MAX_RAM = 1024 * 1024 * availableRAM;
 
-let TARGET_SIZE = _.floor(MAX_RAM / 16); //128 / 16 = 8 (which is UPLOAD_MIN_SIZE)
+/*
+	128 / 16 = 8 (which is UPLOAD_MIN_SIZE)
+	TARGET_SIZE should either be 8MB (since default assumed RAM is 128MB) or
+	1/16 of of the availableRAM, which ever is greater. The TARGET_SIZE, set
+	as `partSize`, will always be used in conjuction with `queueSize`.
+*/
+let TARGET_SIZE = _.floor(MAX_RAM / 16);
 TARGET_SIZE = ( TARGET_SIZE < UPLOAD_MIN_SIZE ? UPLOAD_MIN_SIZE : TARGET_SIZE );
 
 const DEFAULT_UPLOAD_OPTIONS = {
@@ -234,7 +240,9 @@ module.exports = function (options) {
 			if (_.isUndefined(params.length)) { //i.e. if file length is not specified
 				/*
 					Since file size is not known, if `CONNECTOR_MAX_ALLOCATED_RAM_MB`
-					is provided, increase queueSize so that up to 3/4 is used
+					is provided, increase queueSize so that up to 3/4 RAM is used.
+					(1/4 should be left as head room, especially if `CONNECTOR_MAX_ALLOCATED_RAM_MB`
+					is meant to include the connector app itself)
 				*/
 				if (process.env['CONNECTOR_MAX_ALLOCATED_RAM_MB']) {
 					uploadOptions.queueSize = 12;


### PR DESCRIPTION
- Introduced reading of `CONNECTOR_MAX_ALLOCATED_RAM_MB` variable from environment, which is to be used if connector does not run in a lambda function.
- This variable is used to attempt optimisation of stream uploading by modifying `partSize` and
`queueSize`.
- The existing optimisation logic has been updated:
  - Instead of half, up to 3/4 of RAM is now used.
  - MPU case of undefined length is also now handled.