### PR TITLE
[CPS-142] Update prettyTitle to cover capitalising id,ids and url

### DIFF
--- a/lib/buildConnectorsJson/prettyTitle.js
+++ b/lib/buildConnectorsJson/prettyTitle.js
@@ -7,12 +7,14 @@
 var sentenceCase = require('mout/string/sentenceCase');
 var unCamelCase  = require('mout/string/unCamelCase');
 
+// Looks for between word boundaries. Using `gi` so looks for matches globally and case insensitively
 let matchWord = (word) => { return new RegExp(`\\b${word}\\b`, 'gi'); };
 
+const IdRegex = matchWord('id');
+const IdsRegex = matchWord('ids');
+const UrlRegex = matchWord('url');
+
 const handleNameEdgeCases = (name) => {
-	const IdRegex = matchWord('id');
-	const IdsRegex = matchWord('ids');
-	const UrlRegex = matchWord('url');
 	const nameUpperId = name.replace(IdRegex, 'ID');
 	const nameUpperIds = nameUpperId.replace(IdsRegex, 'IDs');
 	return nameUpperIds.replace(UrlRegex, 'URL');

--- a/lib/buildConnectorsJson/prettyTitle.js
+++ b/lib/buildConnectorsJson/prettyTitle.js
@@ -7,6 +7,20 @@
 var sentenceCase = require('mout/string/sentenceCase');
 var unCamelCase  = require('mout/string/unCamelCase');
 
+let matchWord = (word) => { return new RegExp(`\\b${word}\\b`, 'gi'); };
+
+const handleNameEdgeCases = (name) => {
+	const IdRegex = matchWord('id');
+	const IdsRegex = matchWord('ids');
+	const UrlRegex = matchWord('url');
+	const nameUpperId = name.replace(IdRegex, 'ID');
+	const nameUpperIds = nameUpperId.replace(IdsRegex, 'IDs');
+	return nameUpperIds.replace(UrlRegex, 'URL');
+};
+
 module.exports = function (name) {
-	return sentenceCase(unCamelCase(name).replace(/_|-/g, ' '));
+	if (name) {
+		const title = sentenceCase(unCamelCase(name).replace(/_|-/g, ' '));
+		return handleNameEdgeCases(title);
+	}
 };

--- a/lib/buildConnectorsJson/prettyTitle.js
+++ b/lib/buildConnectorsJson/prettyTitle.js
@@ -7,7 +7,7 @@
 var sentenceCase = require('mout/string/sentenceCase');
 var unCamelCase  = require('mout/string/unCamelCase');
 
-// Looks for between word boundaries. Using `gi` so looks for matches globally and case insensitively
+// Looks for words between word boundaries. Using `gi` so looks for matches globally and case insensitively
 let matchWord = (word) => { return new RegExp(`\\b${word}\\b`, 'gi'); };
 
 const IdRegex = matchWord('id');

--- a/lib/buildConnectorsJson/prettyTitle.js
+++ b/lib/buildConnectorsJson/prettyTitle.js
@@ -14,8 +14,8 @@ const IdRegex = matchWord('id');
 const IdsRegex = matchWord('ids');
 const UrlRegex = matchWord('url');
 
-const handleNameEdgeCases = (name) => {
-	const nameUpperId = name.replace(IdRegex, 'ID');
+const handleNameEdgeCases = (sentenceCasedTitle) => {
+	const nameUpperId = sentenceCasedTitle.replace(IdRegex, 'ID');
 	const nameUpperIds = nameUpperId.replace(IdsRegex, 'IDs');
 	return nameUpperIds.replace(UrlRegex, 'URL');
 };

--- a/test/buildConnectorsJson/index.js
+++ b/test/buildConnectorsJson/index.js
@@ -241,6 +241,68 @@ describe('#buildConnectorsJson', function () {
 		assert.equal(parsedJsonSchema[0].messages[0].delivery, 'request_response');
 
 	});
+	
+	it('should autogenerate message titles which include id, ids or url nicely if not already declared', function () {
+
+		var outputJsonString = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							schema: {
+								name: 'my_message_id',
+								input: {
+									name: {
+										type: 'string'
+									}
+								},
+								delivery: 'acknowledge'
+							},
+							model: {
+								url: '..'
+							}
+						},
+						{
+							schema: {
+								name: 'my_second_message_ids',
+								delivery: 'request_response',
+							},
+							model: {}
+						},
+						{
+							schema: {
+								name: 'my_third_message_url',
+								delivery: 'request_response',
+							},
+							model: {}
+						},
+						{
+							schema: {
+								name: 'my_fourth_message_url',
+								title: 'My Amazing 4th message',
+								delivery: 'request_response',
+							},
+							model: {}
+						},
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		var parsedJsonSchema = outputJsonString;
+		assert.equal(parsedJsonSchema[0].messages.length, 4);
+		// remember - operations are sorted by title
+		assert.equal(parsedJsonSchema[0].messages[0].title, 'My Amazing 4th message');
+		assert.equal(parsedJsonSchema[0].messages[0].delivery, 'request_response');
+		assert.equal(parsedJsonSchema[0].messages[1].title, 'My message ID');
+		assert.equal(parsedJsonSchema[0].messages[1].delivery, 'acknowledge');
+		assert.equal(parsedJsonSchema[0].messages[2].title, 'My second message IDs');
+		assert.equal(parsedJsonSchema[0].messages[2].delivery, 'request_response');
+		assert.equal(parsedJsonSchema[0].messages[3].title, 'My third message URL');
+		assert.equal(parsedJsonSchema[0].messages[3].delivery, 'request_response');
+
+	});
 
 	it('should create from specified output schema if specified', function () {
 

--- a/test/buildConnectorsJson/prettyTitle.js
+++ b/test/buildConnectorsJson/prettyTitle.js
@@ -13,9 +13,38 @@ describe('#prettyTitle', function () {
 		assert.equal(prettyTitle('listName'), 'List name');
 	});
 
-	it.skip('should handle some clever edge cases', function () {
+	it('should upper case id', function () {
+		assert.equal(prettyTitle('id'), 'ID');
 		assert.equal(prettyTitle('list_id'), 'List ID');
-		assert.equal(prettyTitle('webhook_url'), 'Webhook URL');
+		assert.equal(prettyTitle('list_id_name'), 'List ID name');
+
+		assert.equal(prettyTitle('lid'), 'Lid');
+		assert.equal(prettyTitle('list baseid'), 'List baseid');
+	});
+
+	it('should upper case ids', function () {
+		assert.equal(prettyTitle('ids'), 'IDs');
+		assert.equal(prettyTitle('list_ids'), 'List IDs');
+		assert.equal(prettyTitle('list_ids_name'), 'List IDs name');
+
+		assert.equal(prettyTitle('lids'), 'Lids');
+		assert.equal(prettyTitle('list baseids'), 'List baseids');
+	});
+
+	it('should upper case url', function () {
+		assert.equal(prettyTitle('url'), 'URL');
+		assert.equal(prettyTitle('list_url'), 'List URL');
+		assert.equal(prettyTitle('list_url_name'), 'List URL name');
+
+		assert.equal(prettyTitle('lurl'), 'Lurl');
+		assert.equal(prettyTitle('list baseurl'), 'List baseurl');
+	});
+
+	it('should globally upper id, ids and urls', function () {
+		assert.equal(prettyTitle('list_id_url_name'), 'List ID URL name');
+		assert.equal(prettyTitle('list_url_id_name'), 'List URL ID name');
+		assert.equal(prettyTitle('list_ids_url_name'), 'List IDs URL name');
+		assert.equal(prettyTitle('list_url_ids_name'), 'List URL IDs name');
 	});
 
 });

--- a/test/buildConnectorsJson/prettyTitle.js
+++ b/test/buildConnectorsJson/prettyTitle.js
@@ -40,7 +40,7 @@ describe('#prettyTitle', function () {
 		assert.equal(prettyTitle('list baseurl'), 'List baseurl');
 	});
 
-	it('should globally upper id, ids and urls', function () {
+	it('should globally upper case id, ids and url', function () {
 		assert.equal(prettyTitle('list_id_url_name'), 'List ID URL name');
 		assert.equal(prettyTitle('list_url_id_name'), 'List URL ID name');
 		assert.equal(prettyTitle('list_ids_url_name'), 'List IDs URL name');


### PR DESCRIPTION
To adhere to connector standards, schema object titles that include id, ids or url should be capitalised.

This currently requires manually setting a title property on the schema object.

This PR adds some regex matching and replacing in prettyTitle.js to cover converting this.