### PR TITLE
CPS-202/CPB-209: Falafel v1.27.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ This function assumes the file is in local storage and will attempt to `createRe
 Generally, when an API provides an upload endpoint, one of falafel's download functions will need to be used. Both of the following download promise functions expect a file pointer object to be passed in.
 
 ##### needleOptions
-Both `falafel.files.streamDownload` and `falafel.files.download` accept a second argument, `needleOptions`, which is an object that can be used to override the default needle options defined when downloading the file (except the `output` property for `falafel.files.download`).
+Both `falafel.files.streamDownload` and `falafel.files.download` accept a second argument, `needleOptions`, which is an object that can be used to override the default needle options defined by falafel when downloading the file (except the `output` property for `falafel.files.download` - falafel takes precedence for this property).
 
 #### `falafel.files.streamDownload` (recommended)
 The `falafel.files.streamDownload` resolving with the following object:

--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ Example:
 ### API download / Falafel upload
 Generally, when an API provides a download endpoint, one of falafel's upload functions will need to be used. All three of the following upload promise functions will return a file pointer object when they resolve.
 
+Note: all signed URLs return an expiry time of 6 hours.
+
+`CONNECTOR_FILE_REGION` and `CONNECTOR_FILE_BUCKET` environment variables can be set to override the default region and bucket.
+
 #### `falafel.files.streamUpload` (recommended)
 The `falafel.files.streamUpload` accepts the following object:
 ```js
@@ -275,6 +279,9 @@ The `falafel.files.streamUpload` accepts the following object:
     name: '[File name]', //required
     length: [File size in bytes], //required
     contentType: '[Mime type of file]', //optional (falafel will attempt to derive it from name if not provided)
+
+    bucket: '[AWS bucket]', //optional target bucket
+    region: '[AWS region]' //optional target region
 }
 ```
 
@@ -289,6 +296,9 @@ The `falafel.files.upload` accepts the following object:
     name: '[File name]', //required
     length: [File size in bytes], //required
     contentType: '[Mime type of file]', //optional (falafel will attempt to derive it from name if not provided)
+
+    bucket: '[AWS bucket]', //optional target bucket
+    region: '[AWS region]' //optional target region
 }
 ```
 This function assumes the file is in local storage and will attempt to `createReadStream` from it; as such this is the least recommended upload option.
@@ -320,6 +330,8 @@ The `falafel.files.download` resolving with the following object:
 }
 ```
 Similarly to `falafel.file.upload`, since this function requires keeping the file in local storage, this is the least recommended download option.
+
+**Note**: when using `falafel.files.download`, `needle.get` is internally used along with the `output` option; needle however only creates a file if the `statusCode` is `200`. If a file needs to be created in the `/tmp` directory for non-200 statusCodes, use `falafel.files.streamDownload`.
 
 ## Trigger connectors
 

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ module.exports = function (params, http) {
     if (http.method === 'post') {
       resolve(http.body);
     } else {
-      reject('#trigger_ignore');
+      reject('#no_trigger');
     }
 
   });

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ module.exports = {
 };
 ```
 
-### Messages
+### Operations (previously Messages)
 
 On a high level, the following rules apply for each message.
 
@@ -140,6 +140,7 @@ module.exports = {
 This schema will be used to generate the `input_schema` for each message. Also, the
 `required` variable applies a validation before the operation executes at runtime.
 
+`type` is a top level schema.js property for which the allowed values are `public`, `ddl`, and `private`. If `type` is not provided, the `public` is assumed by default, unless the operation name ends with `_ddl`. Only `public` and `ddl` operation types are added to the connectors.json.
 
 ### Model
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,9 @@ This function assumes the file is in local storage and will attempt to `createRe
 ### API upload / Falafel download
 Generally, when an API provides an upload endpoint, one of falafel's download functions will need to be used. Both of the following download promise functions expect a file pointer object to be passed in.
 
+##### needleOptions
+Both `falafel.files.streamDownload` and `falafel.files.download` accept a second argument, `needleOptions`, which is an object that can be used to override the default needle options defined when downloading the file (except the `output` property for `falafel.files.download`).
+
 #### `falafel.files.streamDownload` (recommended)
 The `falafel.files.streamDownload` resolving with the following object:
 ```js

--- a/exampleRawHttpRequest/connectors.json
+++ b/exampleRawHttpRequest/connectors.json
@@ -14,7 +14,7 @@
 		"messages": [
 			{
 				"name": "raw_http_request",
-				"title": "Raw HTTP Request (Advanced)",
+				"title": "Raw HTTP request (advanced)",
 				"description": "Perform a raw HTTP request with some pre-configuration and processing by the connector, such as authentication.",
 				"input_schema": {
 					"type": "object",
@@ -58,7 +58,7 @@
 										"full_url": {
 											"type": "string",
 											"description": "The full URL to make the request against. Must begin with `http://` or `https://`.",
-											"title": "Full url"
+											"title": "Full URL"
 										}
 									},
 									"required": [
@@ -70,7 +70,7 @@
 								}
 							],
 							"description": "The URL to make the request with.",
-							"title": "Url"
+							"title": "URL"
 						},
 						"headers": {
 							"type": "array",
@@ -143,10 +143,13 @@
 												"object"
 											],
 											"title": "raw",
+											"description": "Select either `string` to send the body as defined, or `object` to send the body as a JSON object.",
 											"format": "code"
 										}
 									},
-									"required": [],
+									"required": [
+										"raw"
+									],
 									"advanced": [],
 									"additionalProperties": false,
 									"title": "raw",
@@ -164,7 +167,8 @@
 												"oneOf": [
 													{
 														"type": "string",
-														"title": "Text"
+														"title": "Text",
+														"description": "A text value for the property in the form data body."
 													},
 													{
 														"type": "object",
@@ -173,6 +177,7 @@
 														"advanced": [],
 														"additionalProperties": false,
 														"title": "File",
+														"description": "The tray file object to retrieve the contents of and set it as the value for the property in the form data body.",
 														"format": "file"
 													}
 												]
@@ -181,10 +186,13 @@
 											"description": "The form data to perform the request with."
 										}
 									},
-									"required": [],
+									"required": [
+										"form_data"
+									],
 									"advanced": [],
 									"additionalProperties": false,
-									"title": "form-data"
+									"title": "form-data",
+									"description": "The form data body to perform the request with."
 								},
 								{
 									"type": "object",
@@ -201,10 +209,13 @@
 											"description": "The form url encoded data to perform the request with."
 										}
 									},
-									"required": [],
+									"required": [
+										"form_urlencoded"
+									],
 									"advanced": [],
 									"additionalProperties": false,
-									"title": "form-urlencoded"
+									"title": "form-urlencoded",
+									"description": "The form urlencoded body to perform the request with."
 								},
 								{
 									"type": "object",
@@ -220,26 +231,33 @@
 											"format": "file"
 										}
 									},
-									"required": [],
+									"required": [
+										"binary"
+									],
 									"advanced": [],
 									"additionalProperties": false,
-									"title": "binary"
+									"title": "binary",
+									"description": "The file to set as the body to perform the request with."
 								},
 								{
 									"type": "object",
 									"properties": {
 										"none": {
 											"type": "null",
-											"description": "Specify no body to send the request with.",
+											"description": "Send no body in the request.",
 											"title": "None"
 										}
 									},
-									"required": [],
+									"required": [
+										"none"
+									],
 									"advanced": [],
 									"additionalProperties": false,
-									"title": "none"
+									"title": "none",
+									"description": "Select this option to not send a body in the request."
 								}
-							]
+							],
+							"description": "The body type of the request. Select `none` to not send a body."
 						},
 						"include_raw_body": {
 							"type": "boolean",
@@ -279,7 +297,9 @@
 					"required": [
 						"method",
 						"url",
-						"include_raw_body"
+						"body",
+						"include_raw_body",
+						"parse_response"
 					],
 					"advanced": [
 						"include_raw_body",
@@ -343,7 +363,7 @@
 						},
 						"url": {
 							"type": "string",
-							"title": "Url"
+							"title": "URL"
 						}
 					},
 					"required": [

--- a/exampleRawHttpRequest/connectors/testconnector/rawHttpRequest.js
+++ b/exampleRawHttpRequest/connectors/testconnector/rawHttpRequest.js
@@ -2,6 +2,10 @@ module.exports = {
 
 	method: ({ method }) => {
 		return method;
+	},
+
+	schemaOptions: {
+		url: 'all'
 	}
 
 };

--- a/exampleRawHttpRequest/docs.html
+++ b/exampleRawHttpRequest/docs.html
@@ -15,7 +15,7 @@
 		
 		<tr>
 			<td>
-				<em>Raw HTTP Request (Advanced)</em>
+				<em>Raw HTTP request (advanced)</em>
 			</td>
 			<td>
 				Perform a raw HTTP request with some pre-configuration and processing by the connector, such as authentication.

--- a/exampleThree/connectors.json
+++ b/exampleThree/connectors.json
@@ -15,6 +15,7 @@
 			{
 				"name": "file_download",
 				"title": "Test operation",
+				"type": "public",
 				"input_schema": {
 					"type": "object",
 					"properties": {},
@@ -28,6 +29,7 @@
 			{
 				"name": "file_upload",
 				"title": "Test operation",
+				"type": "public",
 				"input_schema": {
 					"type": "object",
 					"properties": {},

--- a/exampleThree/connectors.json
+++ b/exampleThree/connectors.json
@@ -13,6 +13,19 @@
 		},
 		"messages": [
 			{
+				"name": "file_download",
+				"title": "Test operation",
+				"input_schema": {
+					"type": "object",
+					"properties": {},
+					"required": [],
+					"advanced": [],
+					"$schema": "http://json-schema.org/draft-04/schema#",
+					"additionalProperties": false
+				},
+				"dynamic_output": false
+			},
+			{
 				"name": "file_upload",
 				"title": "Test operation",
 				"input_schema": {

--- a/exampleThree/connectors/testconnector/file_download/model.js
+++ b/exampleThree/connectors/testconnector/file_download/model.js
@@ -1,0 +1,31 @@
+
+
+module.exports = function (params) {
+	return new Promise(function (resolve, reject) {
+
+		falafel.files.streamDownload(params.file)
+
+		.then((downloadObject) => {
+
+			let acc = '';
+			downloadObject.readStream
+
+			.on('data', (chunk) => {
+				acc += chunk.toString();
+			})
+
+			.on('end', (chunk) => {
+				if (chunk) {
+					acc += chunk.toString();
+				}
+				resolve(acc);
+			})
+
+			.on('error', reject);
+
+		})
+
+		.catch(reject);
+
+	});
+};

--- a/exampleThree/connectors/testconnector/file_download/schema.js
+++ b/exampleThree/connectors/testconnector/file_download/schema.js
@@ -1,0 +1,12 @@
+module.exports = {
+
+	title: 'Test operation',
+
+	globals: false,
+
+	input: {
+
+	},
+
+
+};

--- a/exampleThree/connectors/testconnector/file_upload/model.js
+++ b/exampleThree/connectors/testconnector/file_upload/model.js
@@ -1,14 +1,38 @@
+const fs = require('fs');
 
-
-module.exports = function () {
-	return when.promise(function (resolve, reject) {
-
-		falafel.files.streamMPUpload({
-			readStream: falafel.helpers.getGalaxyReadStream(),
-			name: 'galaxy.tif'
-		})
-
-		.done(resolve, reject);
-
+module.exports = function (params) {
+	return new Promise(function (resolve, reject) {
+		switch (params.task) {
+			case 'upload':
+				const filePath = `${__dirname}/../../../helpers/galaxy.tif`;
+				falafel.files.upload({
+					file: filePath,
+					name: 'galaxy.tif',
+					length: fs.statSync(filePath).size
+				})
+				.done(resolve, reject);
+				break;
+			case 'streamUpload':
+				falafel.files.streamUpload({
+					readStream: falafel.helpers.getGalaxyReadStream(),
+					name: 'galaxy.tif',
+					length: fs.fstatSync(filePath).size
+				})
+				.done(resolve, reject);
+				break;
+			case 'csv':
+				falafel.files.streamMPUpload({
+					readStream: falafel.helpers.getSampleCSVReadStream(),
+					name: 'sample.csv'
+				})
+				.done(resolve, reject);
+				break;
+			default:
+				falafel.files.streamMPUpload({
+					readStream: falafel.helpers.getGalaxyReadStream(),
+					name: 'galaxy.tif'
+				})
+				.done(resolve, reject);
+		}
 	});
 };

--- a/exampleThree/docs.html
+++ b/exampleThree/docs.html
@@ -22,6 +22,15 @@
 			</td>
 		</tr>
 		
+		<tr>
+			<td>
+				<em>Test operation</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
 	</tbody>
 </table>
 

--- a/exampleThree/helpers/getSampleCSVReadStream.js
+++ b/exampleThree/helpers/getSampleCSVReadStream.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+	return require('fs').createReadStream(__dirname + '/sample.csv');
+};

--- a/exampleThree/helpers/sample.csv
+++ b/exampleThree/helpers/sample.csv
@@ -1,0 +1,3 @@
+id,name,email
+123,blah,天外飞鬼@test.com
+456,xyz,ホサカ@test.com

--- a/exampleTwo/connectors.json
+++ b/exampleTwo/connectors.json
@@ -122,6 +122,27 @@
 				"dynamic_output": false
 			},
 			{
+				"title": "Test op two DDL",
+				"name": "test_op_two_ddl",
+				"type": "ddl",
+				"input_schema": {
+					"type": "object",
+					"properties": {
+						"domain": {
+							"type": "string",
+							"description": "Domain",
+							"title": "Domain"
+						}
+					},
+					"required": [
+						"domain"
+					],
+					"advanced": [],
+					"$schema": "http://json-schema.org/draft-04/schema#",
+					"additionalProperties": false
+				}
+			},
+			{
 				"name": "test_op",
 				"title": "Test operation",
 				"type": "public",

--- a/exampleTwo/connectors.json
+++ b/exampleTwo/connectors.json
@@ -16,9 +16,15 @@
 				"name": "test_date_formatter",
 				"title": "Test date formatter",
 				"description": "Auto formats dates.",
+				"type": "public",
 				"input_schema": {
 					"type": "object",
 					"properties": {
+						"domain": {
+							"type": "string",
+							"description": "Domain",
+							"title": "Domain"
+						},
 						"date": {
 							"type": "number",
 							"format": "date",
@@ -92,7 +98,9 @@
 							"title": "My object"
 						}
 					},
-					"required": [],
+					"required": [
+						"domain"
+					],
 					"advanced": [],
 					"$schema": "http://json-schema.org/draft-04/schema#",
 					"additionalProperties": false
@@ -102,6 +110,7 @@
 			{
 				"name": "test_op_function",
 				"title": "Test function operation",
+				"type": "public",
 				"input_schema": {
 					"type": "object",
 					"properties": {},
@@ -115,6 +124,7 @@
 			{
 				"name": "test_op",
 				"title": "Test operation",
+				"type": "public",
 				"input_schema": {
 					"type": "object",
 					"properties": {
@@ -197,7 +207,7 @@
 											"type": "string",
 											"default": "raw",
 											"format": "hidden",
-											"title": "Id"
+											"title": "ID"
 										},
 										"content": {
 											"type": "string",
@@ -217,7 +227,7 @@
 											"type": "string",
 											"default": "form-data",
 											"format": "hidden",
-											"title": "Id"
+											"title": "ID"
 										},
 										"content": {
 											"type": "array",
@@ -281,7 +291,7 @@
 											"type": "string",
 											"default": "form-urlencoded",
 											"format": "hidden",
-											"title": "Id"
+											"title": "ID"
 										},
 										"content": {
 											"type": "object",
@@ -304,7 +314,7 @@
 											"type": "string",
 											"default": "binary",
 											"format": "hidden",
-											"title": "Id"
+											"title": "ID"
 										},
 										"content": {
 											"type": "object",
@@ -337,9 +347,15 @@
 			{
 				"name": "test_op2",
 				"title": "Test operation",
+				"type": "public",
 				"input_schema": {
 					"type": "object",
 					"properties": {
+						"domain": {
+							"type": "string",
+							"description": "Domain",
+							"title": "Domain"
+						},
 						"test": {
 							"type": "string",
 							"default": "Hello world",
@@ -347,6 +363,7 @@
 						}
 					},
 					"required": [
+						"domain",
 						"test"
 					],
 					"advanced": [],
@@ -372,9 +389,15 @@
 			{
 				"name": "test_op4",
 				"title": "Test operation",
+				"type": "public",
 				"input_schema": {
 					"type": "object",
 					"properties": {
+						"domain": {
+							"type": "string",
+							"description": "Domain",
+							"title": "Domain"
+						},
 						"test": {
 							"type": "object",
 							"properties": {},
@@ -385,6 +408,7 @@
 						}
 					},
 					"required": [
+						"domain",
 						"test"
 					],
 					"advanced": [],
@@ -410,16 +434,24 @@
 			{
 				"name": "test_deepcall",
 				"title": "Test operation 3",
+				"type": "public",
 				"input_schema": {
 					"type": "object",
 					"properties": {
+						"domain": {
+							"type": "string",
+							"description": "Domain",
+							"title": "Domain"
+						},
 						"test": {
 							"type": "string",
 							"default": "Hello world",
 							"title": "Test"
 						}
 					},
-					"required": [],
+					"required": [
+						"domain"
+					],
 					"advanced": [],
 					"$schema": "http://json-schema.org/draft-04/schema#",
 					"additionalProperties": false
@@ -439,6 +471,26 @@
 					"additionalProperties": false
 				},
 				"dynamic_output": false
+			},
+			{
+				"name": "test_op_ddl",
+				"title": "Test operation DDL",
+				"type": "ddl",
+				"input_schema": {
+					"type": "object",
+					"properties": {
+						"dependant_property": {
+							"type": "string",
+							"title": "Dependant property"
+						}
+					},
+					"required": [
+						"dependant_property"
+					],
+					"advanced": [],
+					"$schema": "http://json-schema.org/draft-04/schema#",
+					"additionalProperties": false
+				}
 			}
 		]
 	}

--- a/exampleTwo/connectors/testconnector/global_schema.js
+++ b/exampleTwo/connectors/testconnector/global_schema.js
@@ -7,4 +7,14 @@
 
 module.exports = {
 
+	input: {
+
+		domain: {
+			type: 'string',
+			description: 'Domain',
+			required: true
+		}
+
+	}
+
 };

--- a/exampleTwo/connectors/testconnector/test_op_ddl/model.js
+++ b/exampleTwo/connectors/testconnector/test_op_ddl/model.js
@@ -1,0 +1,10 @@
+module.exports = function (params) {
+	return {
+		results: [
+			{
+				text: 'hello',
+				value: 'world'
+			}
+		]
+	};
+};

--- a/exampleTwo/connectors/testconnector/test_op_ddl/schema.js
+++ b/exampleTwo/connectors/testconnector/test_op_ddl/schema.js
@@ -1,0 +1,17 @@
+module.exports = {
+
+	title: 'Test operation DDL',
+
+	globals: false,
+
+	input: {
+
+		dependant_property: {
+			type: 'string',
+			required: true
+		}
+
+	},
+
+
+};

--- a/exampleTwo/connectors/testconnector/test_op_private/model.js
+++ b/exampleTwo/connectors/testconnector/test_op_private/model.js
@@ -1,0 +1,10 @@
+module.exports = function (params) {
+	return {
+		results: [
+			{
+				text: 'hello',
+				value: 'world'
+			}
+		]
+	};
+};

--- a/exampleTwo/connectors/testconnector/test_op_private/schema.js
+++ b/exampleTwo/connectors/testconnector/test_op_private/schema.js
@@ -1,0 +1,17 @@
+module.exports = {
+
+	type: 'private',
+
+	globals: false,
+
+	input: {
+
+		req_prop: {
+			type: 'string',
+			required: true
+		}
+
+	},
+
+
+};

--- a/exampleTwo/connectors/testconnector/test_op_two_ddl/model.js
+++ b/exampleTwo/connectors/testconnector/test_op_two_ddl/model.js
@@ -1,0 +1,10 @@
+module.exports = function (params) {
+	return {
+		results: [
+			{
+				text: 'hello',
+				value: 'world'
+			}
+		]
+	};
+};

--- a/exampleTwo/docs.html
+++ b/exampleTwo/docs.html
@@ -33,6 +33,15 @@
 		
 		<tr>
 			<td>
+				<em>Test op two DDL</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
+		<tr>
+			<td>
 				<em>Test operation</em>
 			</td>
 			<td>

--- a/exampleTwo/docs.html
+++ b/exampleTwo/docs.html
@@ -67,6 +67,15 @@
 			</td>
 		</tr>
 		
+		<tr>
+			<td>
+				<em>Test operation DDL</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
 	</tbody>
 </table>
 

--- a/lib/bindConnectors/bindTriggerRequest.js
+++ b/lib/bindConnectors/bindTriggerRequest.js
@@ -71,7 +71,7 @@ module.exports = function (message, options) {
 						!shouldTrigger ?
 						// If we shouldn't, pass back the ignore message
 						when.reject({
-							code: '#trigger_ignore',
+							code: '#no_trigger',
 							message: 'Ignore this request.'
 						}) :
 						// if we should, run the `before` method, wrapping in a promise to allow

--- a/lib/bindConnectors/formatError.js
+++ b/lib/bindConnectors/formatError.js
@@ -64,6 +64,8 @@ module.exports = function (response, event) {
 		if (checkThreadneedleError(details)) {
 			newDetailsObject.code = '#connector_error';
 			newDetailsObject.stack = cleanStack(details.stack);
+		} else if (details.code === '#connector_error' && details.stack) {
+			newDetailsObject.stack = cleanStack(details.stack);
 		}
 
 		details = newDetailsObject;

--- a/lib/buildConnectorsJson/index.js
+++ b/lib/buildConnectorsJson/index.js
@@ -1,17 +1,46 @@
-var fs             			 = require('fs');
-var _              			 = require('lodash');
-var GenerateSchema 			 = require('generate-schema');
-var prettyTitle 				 = require('./prettyTitle');
-var generateSchemafromJs = require('./generateSchemaFromJs');
+const fs = require('fs');
 
+const _ = require('lodash');
+const GenerateSchema = require('generate-schema');
+const generateSchemafromJs = require('./generateSchemaFromJs');
+
+const prettyTitle = require('./prettyTitle');
+
+const standardPick = [
+	'name',
+	'title',
+	'description',
+	'delivery',
+	'default'
+];
+const ddlPick = [
+	'name',
+	'title',
+	'description',
+];
+
+function getValidOperationType ({ schema, name, }) {
+	if (!schema) {
+		return ( name && _.endsWith(name, '_ddl') ? 'ddl' : 'private' );
+	}
+
+	const { type } = schema;
+	switch (type) {
+		case 'public':
+		case 'ddl':
+		case 'private':
+			return type;
+		case undefined: {
+			return ( name && _.endsWith(name, '_ddl') ? 'ddl' : 'public' );
+		}
+		default:
+			throw new Error('Invalid operation type. `type` must be public, ddl, or private');
+	}
+}
 
 module.exports = function (directory, config) {
-
-	// console.log(config);
-
-	var connectorsJson = _.map(config || [], function (connectorConfig) {
-
-		var connector = _.pick(connectorConfig, [
+	const connectorsJson = _.map(config || [], function (connectorConfig) {
+		const connector = _.pick(connectorConfig, [
 			'name',
 			'title',
 			'description',
@@ -27,7 +56,7 @@ module.exports = function (directory, config) {
 		//If `branches` provided, validate and add
 		if (!_.isUndefined(connectorConfig.branches)) {
 
-			var branchesErrorMessage = '`branches` must be an array of objects with `name` and `display_name`';
+			const branchesErrorMessage = '`branches` must be an array of objects with `name` and `display_name`';
 
 			if (!_.isArray(connectorConfig.branches)) {
 				throw new Error(branchesErrorMessage);
@@ -35,7 +64,7 @@ module.exports = function (directory, config) {
 
 			connector.branches = [];
 
-			var allValid = _.every(connectorConfig.branches, function (branch) {
+			const allValid = _.every(connectorConfig.branches, function (branch) {
 				var hasProps = branch.name && branch.display_name;
 				return (
 					hasProps ?
@@ -53,65 +82,84 @@ module.exports = function (directory, config) {
 
 		}
 
-		connector.messages = _.filter(_.map(connectorConfig.messages, function (messageConfig) {
+		connector.messages = _.filter(_.map(connectorConfig.messages, (operationConfig) => {
+			const operationType = getValidOperationType(operationConfig);
 
 			// Some methods don't have schemas and should be hidden
-			if ( !messageConfig.schema || (messageConfig.name && messageConfig.name[0] === '#') ) {
+			if (operationType === 'private') {
 				return;
 			}
 
-			var message = _.pick(messageConfig.schema, [
-				'name',
-				'title',
-				'description',
-				'delivery',
-				'default'
-			]);
-			if (messageConfig.schema.helpLink) {
-				message.help_link = messageConfig.schema.helpLink;
-			}
-			if (_.isNumber(messageConfig.schema.timeoutMillis)) {
-				message.timeout_millis = messageConfig.schema.timeoutMillis;
+			//Hash operations should never be public
+			if (operationConfig.name && operationConfig.name[0] === '#') {
+				return;
 			}
 
-			if (messageConfig.schema.auth_scopes) {
-				message.auth_scopes = messageConfig.schema.auth_scopes;
+			if (operationType === 'ddl') {
+				if (operationConfig.schema) {
+					const { title } = operationConfig.schema;
+					if (title) {
+						if (!_.endsWith(title, ' DDL')) {
+							const titleError = new Error('DDL operation titles must end with `DDL` suffix; ' + operationConfig.name);
+							titleError.code = '#connector_error';
+							throw titleError;
+						}
+					}
+					operationConfig.schema.title = title || prettyTitle(operationConfig.name);
+				} else {
+					operationConfig.schema = {
+						title: prettyTitle(operationConfig.name)
+					};
+				}
 			}
 
-			if (!message.title) {
-				message.title = prettyTitle(message.name);
-			}
+			const operationJson = _.pick(
+				operationConfig.schema,
+				( operationType === 'public' ?  standardPick : ddlPick )
+			);
+
+			operationJson.type = operationType;
 
 			// Generate the input
-			if (messageConfig.schema.globals === false) {
-				message.input_schema = generateSchemafromJs(
-					_.extend({}, messageConfig.schema.input || {})
-				);
+			if (operationConfig.schema.globals === false) {
+				operationJson.input_schema = generateSchemafromJs(_.extend({}, operationConfig.schema.input || {}));
 			} else {
-				message.input_schema = generateSchemafromJs(
-					_.extend({}, (connectorConfig.globalSchema || {}).input, messageConfig.schema.input || {})
-				);
-				message.auth_scopes = message.auth_scopes || (connectorConfig.globalSchema || {}).auth_scopes;
+				operationJson.input_schema = generateSchemafromJs(_.extend({}, (connectorConfig.globalSchema || {}).input, operationConfig.schema.input || {}));
+				operationJson.auth_scopes = operationJson.auth_scopes || (connectorConfig.globalSchema || {}).auth_scopes;
 			}
 
 			// Set up the output schema - either manually specified, or generated
-			if (messageConfig.schema.output) {
-				message.output_schema = generateSchemafromJs(messageConfig.schema.output);
-			} else if (messageConfig.schema.responseSample) {
-				message.output_schema = GenerateSchema.json(messageConfig.schema.responseSample);
+			if (operationConfig.schema.output) {
+				operationJson.output_schema = generateSchemafromJs(operationConfig.schema.output);
+			} else if (operationConfig.schema.responseSample) {
+				operationJson.output_schema = GenerateSchema.json(operationConfig.schema.responseSample);
 			}
 
-			// Generate the reply schema
-			if (messageConfig.schema.reply) {
-				message.reply_schema = generateSchemafromJs(
-					_.extend({}, messageConfig.schema.reply)
-				);
+			if (operationType === 'public') {
+				if (operationConfig.schema.helpLink) {
+					operationJson.help_link = operationConfig.schema.helpLink;
+				}
+				if (_.isNumber(operationConfig.schema.timeoutMillis)) {
+					operationJson.timeout_millis = operationConfig.schema.timeoutMillis;
+				}
+
+				if (!operationJson.title) {
+					operationJson.title = prettyTitle(operationJson.name);
+				}
+
+				// Generate the reply schema
+				if (operationConfig.schema.reply) {
+					operationJson.reply_schema = generateSchemafromJs(_.extend({}, operationConfig.schema.reply));
+				}
+
+				operationJson['dynamic_output'] = ( operationConfig.dynamicOutput ? true : false );
 			}
 
-			message['dynamic_output'] = ( messageConfig.dynamicOutput ? true : false );
+			if (operationConfig.schema.auth_scopes) {
+				operationJson.auth_scopes = operationConfig.schema.auth_scopes;
+			}
 
-			return message;
-
+			return operationJson;
 		}));
 
 		// Sort connector messages by their title
@@ -120,7 +168,6 @@ module.exports = function (directory, config) {
 		});
 
 		return connector;
-
 	});
 
 	if (_.isString(directory)) {
@@ -129,6 +176,4 @@ module.exports = function (directory, config) {
 
 	//Stringify then parse, such that only a JSON compliant object is returned
 	return JSON.parse(JSON.stringify(connectorsJson));
-
-
 };

--- a/lib/buildConnectorsJson/index.js
+++ b/lib/buildConnectorsJson/index.js
@@ -118,6 +118,7 @@ module.exports = function (directory, config) {
 				( operationType === 'public' ?  standardPick : ddlPick )
 			);
 
+			operationJson.name = operationJson.name || operationConfig.name;
 			operationJson.type = operationType;
 
 			// Generate the input

--- a/lib/buildConnectorsJson/prettyTitle.js
+++ b/lib/buildConnectorsJson/prettyTitle.js
@@ -13,12 +13,15 @@ let matchWord = (word) => { return new RegExp(`\\b${word}\\b`, 'gi'); };
 const IdRegex = matchWord('id');
 const IdsRegex = matchWord('ids');
 const UrlRegex = matchWord('url');
+const DdlRegex = matchWord('ddl');
 
-const handleNameEdgeCases = (sentenceCasedTitle) => {
-	const nameUpperId = sentenceCasedTitle.replace(IdRegex, 'ID');
-	const nameUpperIds = nameUpperId.replace(IdsRegex, 'IDs');
-	return nameUpperIds.replace(UrlRegex, 'URL');
-};
+function handleNameEdgeCases (sentenceCasedTitle) {
+	return sentenceCasedTitle
+	.replace(IdRegex, 'ID')
+	.replace(IdsRegex, 'IDs')
+	.replace(UrlRegex, 'URL')
+	.replace(DdlRegex, 'DDL');
+}
 
 module.exports = function (name) {
 	if (name) {

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -47,6 +47,53 @@ const DEFAULT_UPLOAD_OPTIONS = {
 	queueSize: 4 //Ensures at least up to 1/4 of the RAM is utilised
 };
 
+const REQUIRED_FILE_PROPS = [
+	{
+		key: 'name',
+		validator: _.isString
+	}, 
+	{
+		key: 'url',
+		validator: _.isString
+	},
+	{
+		key: 'mime_type',
+		validator: _.isString
+	},
+	{
+		key: 'expires',
+		validator: _.isInteger
+	}
+];
+
+const runFileValidation = (fileObj) => {
+	for (const prop of REQUIRED_FILE_PROPS) {
+		const fileKey = prop.key;
+		const value = fileObj[fileKey];
+
+		if (!value) {
+			return {
+				message: `The '${fileKey}' property is missing. The file object passed through must contain all properties 'name', 'url', 'mime_type', 'expires'.`
+			};
+		}
+
+		if (!prop.validator(value)) {
+			return {
+				message: `The file object passed through contains invalid type for the '${fileKey}' key.`
+			};
+		}
+	}
+
+	return true;
+};
+
+const throwFileValidationErr = (message) => {
+	return when.reject({
+		code: '#connector_error',
+		message
+	});
+}; 
+
 function logError (errorName, error) {
 	// eslint-disable-next-line no-console
 	console.error(errorName, util.inspect(error, { depth: null }));
@@ -373,6 +420,13 @@ module.exports = function (options) {
 		was returned via the `upload` function above in a previous workflow step.
 	*/
 	const download = function (file, needleOptions = {}) {
+
+		const validationResult = runFileValidation(file);
+
+		if (_.isObject(validationResult)) {
+			return throwFileValidationErr(validationResult.message);
+		}
+
 		return when.promise(function (resolve, reject) {
 
 			//In v2, change this, to avoid overwriting if same name was specified twice
@@ -424,6 +478,13 @@ module.exports = function (options) {
 		`readStream` property instead of a `file` property
 	*/
 	const streamDownload = function (file, needleOptions = {}) {
+
+		const validationResult = runFileValidation(file);
+
+		if (_.isObject(validationResult)) {
+			return throwFileValidationErr(validationResult.message);
+		}
+        
 		return when.promise(function (resolve, reject) {
 
 			const getStream = needle.get(

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -2,7 +2,9 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const { PassThrough } = require('stream');
+const { URL } = require('url');
 
+const _ = require('lodash');
 const when = require('when');
 const guid = require('mout/random/guid');
 const mime = require('mime');
@@ -12,11 +14,19 @@ const needle = require('needle');
 
 const AWS = require('aws-sdk');
 
-const REGION = 'us-west-2',
-	BUCKET = 'workflow-file-uploads',
-	DEV_BUCKET = 'workflow-file-uploads-dev';
+const {
+	AWS_LAMBDA_FUNCTION_MEMORY_SIZE,
+	CONNECTOR_MAX_ALLOCATED_RAM_MB,
+	CONNECTOR_FILE_REGION,
+	CONNECTOR_FILE_BUCKET,
+	CONNECTOR_FILE_DEV_BUCKET,
+} = process.env;
 
-const ALLOCATED_RAM = process.env['AWS_LAMBDA_FUNCTION_MEMORY_SIZE'] || process.env['CONNECTOR_MAX_ALLOCATED_RAM_MB'];
+const REGION = CONNECTOR_FILE_REGION || 'us-west-2',
+	BUCKET = CONNECTOR_FILE_BUCKET || 'workflow-file-uploads',
+	DEV_BUCKET = CONNECTOR_FILE_DEV_BUCKET || 'workflow-file-uploads-dev';
+
+const ALLOCATED_RAM = AWS_LAMBDA_FUNCTION_MEMORY_SIZE || CONNECTOR_MAX_ALLOCATED_RAM_MB;
 const availableRAM = ( ALLOCATED_RAM ? _.parseInt(ALLOCATED_RAM) : 128 ); //128MB default
 
 const UPLOAD_MIN_SIZE = 1024 * 1024 * 8, //8MB
@@ -58,7 +68,10 @@ module.exports = function (options) {
 
 	const TARGET_BUCKET = ( options.dev || options.test ? DEV_BUCKET : BUCKET );
 
-	//Pull the AWS creds from environment if present
+	/*
+		Pull the AWS creds from environment if present, else check if
+		options.aws is provided
+	*/
 	if (_.isPlainObject(options.aws)) {
 		if (options.dev) {
 			// eslint-disable-next-line no-console
@@ -83,6 +96,51 @@ module.exports = function (options) {
 				error: rejectError.message || undefined
 			}
 		};
+	}
+
+	function s3Upload ({ params, fileGuidName, mimeType, uploadParams, uploadOptions = {} }) {
+		return new Promise((resolve, reject) => {
+			const s3 = new AWS.S3({ region: params.region || REGION });
+
+			s3.upload(
+				uploadParams,
+				uploadOptions,
+				(fileUploadError, data) => {
+
+					if (fileUploadError) {
+						logError('[ERROR] fileUploadError', fileUploadError);
+						return reject(formatUploadRejectObject(fileUploadError));
+					}
+
+					const sixHourPeriod = moment().add(6, 'hours');
+
+					s3.getSignedUrl(
+						'getObject',
+						{
+							Bucket: data.Bucket || params.bucket || TARGET_BUCKET,
+							Key: data.Key || fileGuidName,
+							Expires: sixHourPeriod.unix() - moment().unix()
+						},
+						(fileUploadSigningError, signedUrl) => {
+
+							if (fileUploadSigningError) {
+								logError('[ERROR] fileUploadSigningError', fileUploadSigningError);
+								return reject(formatUploadRejectObject(fileUploadSigningError));
+							}
+
+							resolve({
+								name: params.name,
+								url: signedUrl,
+								mime_type: mimeType,
+								expires: sixHourPeriod.unix()
+							});
+
+						}
+					);
+
+				}
+			);
+		});
 	}
 
 	/*
@@ -135,44 +193,13 @@ module.exports = function (options) {
 
 			}
 
-			const s3 = new AWS.S3({ region: params.region || REGION });
-
-			s3.upload(uploadParams, function (fileUploadError, data) {
-
-				if (fileUploadError) {
-					logError('[ERROR] fileUploadError', fileUploadError);
-					return reject(formatUploadRejectObject(fileUploadError));
-				}
-
-				const twentyFourHourPeriod = moment().add(1, 'days');
-
-
-				s3.getSignedUrl(
-					'getObject',
-					{
-						Bucket: params.bucket || TARGET_BUCKET,
-						Key: fileGuidName,
-						Expires: twentyFourHourPeriod.unix() - moment().unix()
-					},
-					function (fileUploadSigningError, signedUrl) {
-
-						if (fileUploadSigningError) {
-							logError('[ERROR] fileUploadSigningError', fileUploadSigningError);
-							return reject(formatUploadRejectObject(fileUploadError));
-						}
-
-						resolve({
-							name: params.name,
-							url: signedUrl,
-							mime_type: mimeType,
-							expires: twentyFourHourPeriod.unix()
-						});
-
-					}
-				);
-
-			});
-
+			s3Upload({
+				params,
+				fileGuidName,
+				mimeType,
+				uploadParams,
+			})
+			.then(resolve, reject);
 		});
 	};
 
@@ -244,7 +271,7 @@ module.exports = function (options) {
 					(1/4 should be left as head room, especially if `CONNECTOR_MAX_ALLOCATED_RAM_MB`
 					is meant to include the connector app itself)
 				*/
-				if (process.env['CONNECTOR_MAX_ALLOCATED_RAM_MB']) {
+				if (CONNECTOR_MAX_ALLOCATED_RAM_MB) {
 					uploadOptions.queueSize = 12;
 				}
 			} else { //i.e. if file length is specified
@@ -264,49 +291,16 @@ module.exports = function (options) {
 			const passThroughStream = new PassThrough({ highWaterMark: uploadOptions.partSize });
 			uploadParams.Body = passThroughStream;
 
-			const s3 = new AWS.S3({ region: params.region || REGION });
-
-			s3.upload(
+			s3Upload({
+				params,
+				fileGuidName,
+				mimeType,
 				uploadParams,
-				uploadOptions,
-				function (fileUploadError, data) {
-
-					if (fileUploadError) {
-						logError('[ERROR] fileUploadError', fileUploadError);
-						return reject(formatUploadRejectObject(fileUploadError));
-					}
-
-					const twentyFourHourPeriod = moment().add(1, 'days');
-
-					s3.getSignedUrl(
-						'getObject',
-						{
-							Bucket: params.bucket || TARGET_BUCKET,
-							Key: fileGuidName,
-							Expires: twentyFourHourPeriod.unix() - moment().unix()
-						},
-						function (fileUploadSigningError, signedUrl) {
-
-							if (fileUploadSigningError) {
-								logError('[ERROR] fileUploadSigningError', fileUploadSigningError);
-								return reject(formatUploadRejectObject(fileUploadSigningError));
-							}
-
-							resolve({
-								name: params.name,
-								url: signedUrl,
-								mime_type: mimeType,
-								expires: twentyFourHourPeriod.unix()
-							});
-
-						}
-					);
-
-				}
-			);
+				uploadOptions
+			})
+			.then(resolve, reject);
 
 			params.readStream.pipe(passThroughStream);
-
 		});
 
 	};
@@ -324,42 +318,102 @@ module.exports = function (options) {
 		};
 	}
 
+	//Check if the URL and response is a pre-signed URL from AWS
+	function checkAndGetExpiry (url, headers, rawBody) {
+		const isMetaValid = _.includes(headers['content-type'], 'application/xml') &&
+		_.includes(headers.server, 'AmazonS3') &&
+		_.includes(rawBody.toString(), 'Request has expired');
+
+		if (!isMetaValid) {
+			return false;
+		}
+
+		const currentDatetime = moment();
+		const targetUrl = new URL(url);
+
+		if (_.includes(url, 'Expires=')) {
+			let expiryDatetime = targetUrl.searchParams.get('Expires');
+			if (expiryDatetime) {
+				expiryDatetime = moment(expiryDatetime, 'X');
+				if (currentDatetime.isAfter(expiryDatetime)) {
+					return expiryDatetime.format();
+				}
+			}
+		}
+
+		if (_.includes(url, 'X-Amz-Date=') && _.includes(url, 'X-Amz-Expires=')) {
+			const creationDatetime = targetUrl.searchParams.get('X-Amz-Date');
+			const duration = targetUrl.searchParams.get('X-Amz-Expires');
+			if (creationDatetime && duration) {
+				const expiryDatetime = moment(creationDatetime, 'YYYYMMDD[T]HHmmss[Z]').add(duration, 's');
+				if (currentDatetime.isAfter(expiryDatetime)) {
+					return expiryDatetime.format();
+				}
+			}
+		}
+
+		return false;
+	}
+
+	function expiryRejectObject (expiryDatetime) {
+		const payload = {};
+		if (expiryDatetime) {
+			//snake_case as this is exposed to the user
+			payload.datetime_expired = expiryDatetime;
+		}
+		return {
+			code: '#user_input_error',
+			message: 'The file provided has expired. Please note that links to files downloaded by connectors expire within 6 hours.',
+			payload
+		};
+	}
+
 	/*
 		Download a file from S3. The object passed here should have been one that
 		was returned via the `upload` function above in a previous workflow step.
 	*/
-	const download = function (file) {
+	const download = function (file, needleOptions = {}) {
 		return when.promise(function (resolve, reject) {
 
+			//In v2, change this, to avoid overwriting if same name was specified twice
 			const fileName = '/tmp/' + (file.name || guid());
 
-			needle.get(file.url, {
-				parse: false,
-				open_timeout: 0,
-				read_timeout: 0,
-				output: fileName,
-			}, function (err, res) {
+			needle.get(
+				file.url,
+				{
+					follow_max: 3,
+					decode_response: false,
+					parse: false,
+					open_timeout: 0,
+					read_timeout: 0,
+					...needleOptions,
+					output: fileName,
+				},
+				function (err, res) {
+					if (err) { return reject(formatDownloadRejectObject(err)); }
 
-				if (err) {
-					return reject(formatDownloadRejectObject(err));
-				}
+					//NOTE: needle only creates output file if statusCode is 200
+					if (res.statusCode === 200) {
+						// Resolve with:
+						return resolve({
+							// The contents that was downloaded
+							file: fileName,
 
-				if (_.inRange(res.statusCode, 200, 300)) {
-					// Resolve with
-					resolve({
-						// The contents that was downloaded
-						file: fileName,
-
-						// Pass back what was passed in to be helpful
-						name: file.name,
-						mime_type: file.mime_type,
-						expires: file.expires
-					});
-				} else {
+							// Pass back what was passed in to be helpful
+							name: file.name,
+							mime_type: file.mime_type,
+							expires: file.expires
+						});
+					}
+					if (_.inRange(res.statusCode, 400, 500)) {
+						const expiryDatetime = checkAndGetExpiry(file.url, res.headers, res.raw);
+						if (expiryDatetime) {
+							return reject(expiryRejectObject(expiryDatetime));
+						}
+					}
 					reject(formatDownloadRejectObject(new Error('Status code: ' + res.statusCode)));
 				}
-
-			});
+			);
 
 		});
 	};
@@ -369,18 +423,20 @@ module.exports = function (options) {
 		A stream variant of download, which resolve with an object with a
 		`readStream` property instead of a `file` property
 	*/
-	const streamDownload = function (file) {
+	const streamDownload = function (file, needleOptions = {}) {
 		return when.promise(function (resolve, reject) {
 
 			const getStream = needle.get(
 				file.url,
 				{
+					decode_response: false,
 					parse: false,
 					open_timeout: 0,
-					read_timeout: 0
+					read_timeout: 0,
+					...needleOptions
 				}
 			)
-			.on('header', function (statusCode, headers) {
+			.on('header', async function (statusCode, headers) {
 
 				if (_.inRange(statusCode, 200, 300)) {
 					resolve({
@@ -393,7 +449,42 @@ module.exports = function (options) {
 						size: headers['content-length']
 					});
 				} else {
-					reject(formatDownloadRejectObject(new Error('Status code: ' + statusCode)));
+					let expiryCheckTimeout;
+					try {
+						const expiryDatetime = await new Promise((expiredResolve, expiredReject) => {
+							if (!_.inRange(statusCode, 400, 500)) {
+								return expiredReject();
+							}
+
+							//Reject if expiry cannot be determined within 10 seconds
+							expiryCheckTimeout = setTimeout(function () {
+								expiredReject();
+							}, 10000);
+
+							let acc;
+							function dataConsumer (chunk) {
+								acc += chunk.toString();
+								const expiryDatetimeResult = checkAndGetExpiry(file.url, headers, acc);
+								if (expiryDatetimeResult) {
+									expiredResolve(expiryDatetimeResult);
+									clearTimeout(expiryCheckTimeout);
+									getStream.removeListener('data', dataConsumer);
+								}
+							}
+
+							getStream.on('data', dataConsumer);
+							getStream.on('error', expiredReject);
+							getStream.on('end', expiredReject);
+						});
+						//If it gets to here, checkAndGetExpiry call resolved
+						reject(expiryRejectObject(expiryDatetime));
+					} catch (err) {
+						reject(formatDownloadRejectObject(new Error('Status code: ' + statusCode)));
+					} finally {
+						if (expiryCheckTimeout) {
+							clearTimeout(expiryCheckTimeout);
+						}
+					}
 				}
 
 			})

--- a/lib/index.js
+++ b/lib/index.js
@@ -153,9 +153,10 @@ var Falafel = function () {
 
 			}
 
-
+			const disableDevServer = options.disableDevServer || 
+				!!process.env.FALAFEL_DISABLE_DEV_SERVER;
 			// Spin up a dev server for testing via Postman on dev
-			if (options.dev === true) {
+			if (options.dev === true && !disableDevServer) {
 				require('./devServer')(apptalk);
 			}
 

--- a/lib/parseConfig/getFunctionParameter.js
+++ b/lib/parseConfig/getFunctionParameter.js
@@ -2,21 +2,22 @@
 * Given a function parameter, return a function that can be run at runtime
 * which evaluates the function string, and errors if required.
 */
-var when = require('when');
-var _ = require('lodash');
+const _ = require('lodash');
+const when = require('when');
 
-module.exports = function (parameter, key) {
+module.exports = function (parameter, key, topLevelName) {
 	return function () {
 		try {
-			eval('var evaluatedFn = '+parameter.value);	
+			eval('var evaluatedFn = '+parameter.value);
 			if (_.isFunction(evaluatedFn)) {
-				return evaluatedFn.apply(null, arguments);	
+				return evaluatedFn.apply(null, arguments);
 			} else {
 				throw new Error('Should be a function');
 			}
-		} catch (e) {
-			var helpfulError = new Error('Error evaluating operation "'+key+'": '+e.message);
-			helpfulError.stack = e.stack;
+		} catch (functionError) {
+			const helpfulError = new Error(`Error occured for module '${topLevelName}'. Error evaluating function '${key}': ${functionError.message}`);
+			helpfulError.stack = functionError.stack;
+			helpfulError.code = '#connector_error';
 			throw helpfulError;
 		}
 	};

--- a/lib/parseConfig/getGlobalModel.js
+++ b/lib/parseConfig/getGlobalModel.js
@@ -5,14 +5,12 @@ var handleOAuthRefresh      = require('./handleOAuthRefresh');
 
 module.exports = function (config) {
 
-	var model = normalizeModelParameter(config.model);
+	var model = normalizeModelParameter(config.model, 'globalModel');
 
 
 	if (_.isFunction(model)) {
 		return model;
-	}
-
-	else {
+	} else {
 
 		// Auth is a special parameter that gets merged into the query and
 		// headers parameters.
@@ -41,7 +39,7 @@ module.exports = function (config) {
 				});
 
 				return query;
-			}()),
+			})(),
 
 			options: (function () {
 				var options = {
@@ -75,7 +73,7 @@ module.exports = function (config) {
 				}
 
 				return options;
-			}()),
+			})(),
 
 			expects: model.expects,
 

--- a/lib/parseConfig/getHelper.js
+++ b/lib/parseConfig/getHelper.js
@@ -4,5 +4,5 @@
 var getFunctionParameter = require('./getFunctionParameter');
 
 module.exports = function (helperParameter, helperKey) {
-	return getFunctionParameter(helperParameter, helperKey);
+	return getFunctionParameter(helperParameter, 'helper', helperKey);
 };

--- a/lib/parseConfig/getModel.js
+++ b/lib/parseConfig/getModel.js
@@ -4,14 +4,12 @@ var normalizeModelParameter = require('./normalizeModelParameter');
 
 module.exports = function (operation) {
 
-	var model = normalizeModelParameter(operation.model);
+	var model = normalizeModelParameter(operation.model, operation.name);
 
 
 	if (_.isFunction(model)) {
 		return model;
-	}
-
-	else {
+	} else {
 		return {
 
 			method: model.method,
@@ -36,7 +34,7 @@ module.exports = function (operation) {
 				});
 
 				return query;
-			}()),
+			})(),
 
 			options: (function () {
 
@@ -63,7 +61,7 @@ module.exports = function (operation) {
 					_.assign({}, model.options, options) :
 					options
 				);
-			}()),
+			})(),
 
 			expects: model.expects,
 

--- a/lib/parseConfig/normalizeModelParameter.js
+++ b/lib/parseConfig/normalizeModelParameter.js
@@ -1,18 +1,18 @@
 /*
 * Denormalize a model parameter to get the "pure" parameter as it should
 * be passed into Falafel.
-* 
+*
 * Currently this is only done for the `data` key, in post/put/patch/delete requests.
 */
 var _ = require('lodash');
 var getFunctionParameter = require('./getFunctionParameter');
 
 
-module.exports = function (parameter) {
+module.exports = function (parameter, topLevelName) {
 
 	var normalized = {};
 
-	function normalize(param, keyPath) {
+	function normalize (param, keyPath) {
 
 		// set all of the keys beneath an object
 		if (param.type === 'object') {
@@ -20,7 +20,7 @@ module.exports = function (parameter) {
 			_.each(param.value, function (subParam, subKey) {
 				normalize(subParam, keyPath+'.'+subKey);
 			});
-		} 
+		}
 
 		// set a blank array, and add all of the children to it
 		else if (param.type === 'array') {
@@ -28,13 +28,13 @@ module.exports = function (parameter) {
 			_.each(param.value, function (item, index) {
 				return normalize(item, keyPath+'['+index+']');
 			});
-		} 
+		}
 
-		// return a function that can be evaluated, if a function has actually 
+		// return a function that can be evaluated, if a function has actually
 		// been declared
 		else if (param.type === 'function') {
 			if (param.value) {
-				_.set(normalized, keyPath, getFunctionParameter(param, keyPath));	
+				_.set(normalized, keyPath, getFunctionParameter(param, keyPath, topLevelName));
 			}
 		}
 
@@ -49,15 +49,15 @@ module.exports = function (parameter) {
 	if (parameter.type === 'object') {
 		_.each(parameter.value, function (param, key) {
 			normalize(param, key);
-		});	
+		});
 	}
 
 	// For function parameters, simply get the function parameter.
-	// If the function parameter has no value, then fall back to a function 
+	// If the function parameter has no value, then fall back to a function
 	// that just returns a blank object.
 	else if (parameter.type === 'function') {
 		if (parameter.value) {
-			normalized = getFunctionParameter(parameter);	
+			normalized = getFunctionParameter(parameter, topLevelName, topLevelName);
 		} else {
 			normalized = function () {
 				return {};

--- a/lib/rawHttpRequest/formatOutput.js
+++ b/lib/rawHttpRequest/formatOutput.js
@@ -11,7 +11,7 @@ module.exports = (body, params, res) => {
 		}
 	}
 	const result = {
-		status_code: res.status_code,
+		status_code: res.statusCode,
 		headers: res.headers,
 		body: body
 	};
@@ -25,5 +25,5 @@ module.exports = (body, params, res) => {
 		throw payloadSizeError;
 	}
 
-	return result;
+	return { response: result };
 };

--- a/lib/rawHttpRequest/index.js
+++ b/lib/rawHttpRequest/index.js
@@ -40,6 +40,23 @@ function setupRawHttpRequestOperationConfig (connectorsConfig) {
 				);
 			}
 
+			const { schemaOptions = {} } = connectorConfig.rawHttpRequest;
+			if (_.isString(schemaOptions.url)) {
+				const originalUrlOneOf = rawHttpRequestSchema.input.url.oneOf;
+				switch (schemaOptions.url) {
+					case 'endpointOnly':
+						schemaToUse.input.url.oneOf = [originalUrlOneOf[0]];
+						break;
+					case 'fullOnly':
+						schemaToUse.input.url.oneOf = [originalUrlOneOf[1]];
+						break;
+					case 'all':
+					default:
+						//No change; provide both endpoint and full
+						break;
+				}
+			}
+
 			const opConfig = {
 
 				name: RAW_HTTP_REQUEST_OP_NAME,

--- a/lib/rawHttpRequest/rawHttpRequestSchema.js
+++ b/lib/rawHttpRequest/rawHttpRequestSchema.js
@@ -1,6 +1,6 @@
 module.exports = {
 
-	title: 'Raw HTTP Request (Advanced)',
+	title: 'Raw HTTP request (advanced)',
 
 	description: 'Perform a raw HTTP request with some pre-configuration and processing by the connector, such as authentication.',
 
@@ -31,6 +31,7 @@ module.exports = {
 				{
 					title: 'Endpoint',
 					type: 'object',
+					required: true,
 					properties: {
 
 						endpoint: {
@@ -45,6 +46,7 @@ module.exports = {
 				{
 					title: 'Full URL',
 					type: 'object',
+					required: true,
 					properties: {
 
 						full_url: {
@@ -107,7 +109,9 @@ module.exports = {
 
 		body: {
 			title: 'Body Type',
+			description: 'The body type of the request. Select `none` to not send a body.',
 			additionalProperties: false,
+			required: true,
 			oneOf: [
 
 				{
@@ -115,20 +119,25 @@ module.exports = {
 					type: 'object',
 					description: 'The raw body to perform the request with.',
 					additionalProperties: false,
+					required: true,
 					properties: {
 						raw: {
 							type: [ 'string', 'object' ],
 							title: 'raw',
+							description: 'Select either `string` to send the body as defined, or `object` to send the body as a JSON object.',
 							format: 'code',
-							additionalProperties: true
+							additionalProperties: true,
+							required: true
 						},
 					},
 				},
 
 				{
 					title: 'form-data',
+					description: 'The form data body to perform the request with.',
 					type: 'object',
 					additionalProperties: false,
+					required: true,
 					properties: {
 						form_data: {
 							type: 'object',
@@ -138,25 +147,30 @@ module.exports = {
 								oneOf: [
 									{
 										title: 'Text',
+										description: 'A text value for the property in the form data body.',
 										type: 'string',
 									},
 
 									{
 										title: 'File',
+										description: 'The tray file object to retrieve the contents of and set it as the value for the property in the form data body.',
 										type: 'object',
 										format: 'file',
 										additionalProperties: false,
 									},
 								],
 							},
+							required: true
 						},
 					},
 				},
 
 				{
 					title: 'form-urlencoded',
+					description: 'The form urlencoded body to perform the request with.',
 					type: 'object',
 					additionalProperties: false,
+					required: true,
 					properties: {
 						form_urlencoded: {
 							type: 'object',
@@ -165,31 +179,38 @@ module.exports = {
 							additionalProperties: {
 								type: 'string',
 							},
+							required: true
 						},
 					},
 				},
 
 				{
 					title: 'binary',
+					description: 'The file to set as the body to perform the request with.',
 					type: 'object',
 					additionalProperties: false,
+					required: true,
 					properties: {
 						binary: {
 							type: 'object',
 							title: 'binary',
 							description: 'The binary from a file to perform the request with.',
 							format: 'file',
+							required: true
 						},
 					},
 				},
 
 				{
 					title: 'none',
+					description: 'Select this option to not send a body in the request.',
 					type: 'object',
+					required: true,
 					properties: {
 						none: {
 							type: 'null',
-							description: 'Specify no body to send the request with.',
+							description: 'Send no body in the request.',
+							required: true
 						},
 					},
 				},
@@ -231,6 +252,7 @@ module.exports = {
 				},
 			],
 			default: 'true',
+			required: true,
 			advanced: true,
 		},
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,28 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.1"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+      "dev": true
+    },
     "@babel/highlight": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.10.1",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
@@ -50,14 +56,14 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz",
-      "integrity": "sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg=="
+      "version": "14.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.11.tgz",
+      "integrity": "sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg=="
     },
     "@types/request": {
-      "version": "2.48.4",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
-      "integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
+      "version": "2.48.5",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
       "requires": {
         "@types/caseless": "*",
         "@types/node": "*",
@@ -66,9 +72,9 @@
       }
     },
     "@types/tough-cookie": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
-      "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -87,9 +93,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -99,15 +105,21 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.1",
@@ -139,6 +151,16 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -191,6 +213,12 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "aws-sdk": {
       "version": "2.413.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.413.0.tgz",
@@ -225,9 +253,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -247,6 +275,12 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
     },
     "bluebird": {
       "version": "3.7.2",
@@ -322,6 +356,15 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -393,6 +436,22 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -403,10 +462,46 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
     },
     "coffeescript": {
       "version": "1.10.0",
@@ -566,6 +661,15 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -628,6 +732,36 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-html": {
@@ -704,9 +838,9 @@
       }
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -723,9 +857,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
+      "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==",
       "dev": true
     },
     "espree": {
@@ -746,12 +880,20 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
-      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
@@ -988,6 +1130,15 @@
         "merge-descriptors": "~1.0.0"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -1045,6 +1196,15 @@
         }
       }
     },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -1057,9 +1217,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "forever-agent": {
@@ -1088,10 +1248,35 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -1108,6 +1293,12 @@
         "commander": "^2.9.0",
         "type-of-is": "^3.4.0"
       }
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -1144,9 +1335,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -1162,9 +1353,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "growl": {
@@ -1224,10 +1415,20 @@
             "resolve": "~1.1.0"
           }
         },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "mkdirp": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-          "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         },
         "resolve": {
@@ -1321,16 +1522,31 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "hooker": {
@@ -1534,6 +1750,33 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1561,17 +1804,35 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+    "is-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1612,9 +1873,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1652,6 +1913,16 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1698,10 +1969,37 @@
         }
       }
     },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -1756,21 +2054,21 @@
       "dev": true
     },
     "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "mimic-fn": {
@@ -1818,52 +2116,68 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
       "dev": true,
       "requires": {
+        "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
         "growl": "1.10.5",
-        "he": "1.1.1",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "dev": true
-        },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
           }
         },
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1874,25 +2188,32 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -1971,6 +2292,53 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nock": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
+      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -2000,6 +2368,12 @@
         }
       }
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -2010,6 +2384,40 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2055,6 +2463,30 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "parent-module": {
@@ -2129,6 +2561,12 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -2162,6 +2600,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -2184,9 +2628,9 @@
       }
     },
     "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -2286,6 +2730,15 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -2355,10 +2808,22 @@
         }
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -2390,27 +2855,24 @@
       }
     },
     "run-async": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "rxjs": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2471,6 +2933,12 @@
         "send": "0.17.1"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -2492,9 +2960,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "slice-ansi": {
@@ -2551,9 +3019,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -2561,15 +3029,15 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -2636,6 +3104,48 @@
         }
       }
     },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2676,9 +3186,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
       "dev": true
     },
     "supports-color": {
@@ -2748,6 +3258,15 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -2769,9 +3288,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "tunnel-agent": {
@@ -2856,6 +3375,12 @@
         }
       }
     },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "dev": true
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2903,9 +3428,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -2948,6 +3473,54 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "winston": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
@@ -2967,6 +3540,42 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2983,9 +3592,9 @@
       }
     },
     "xml-crypto": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-1.4.0.tgz",
-      "integrity": "sha512-K8FRdRxICVulK4WhiTUcJrRyAIJFPVOqxfurA3x/JlmXBTxy+SkEENF6GeRt7p/rB6WSOUS9g0gXNQw5n+407g==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-1.5.3.tgz",
+      "integrity": "sha512-uHkmpUtX15xExe5iimPmakAZN+6CqIvjmaJTy4FwqGzaTjrKRBNeqMh8zGEzVNgW0dk6beFYpyQSgqV/J6C5xA==",
       "requires": {
         "xmldom": "0.1.27",
         "xpath": "0.0.27"
@@ -3014,6 +3623,93 @@
       "version": "0.0.27",
       "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
       "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0-alpha.0",
+  "version": "1.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0",
+  "version": "1.27.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0",
+  "version": "1.27.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1988,9 +1988,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "log-symbols": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -43,10 +43,16 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/node": {
-      "version": "13.1.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
-      "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
+      "version": "13.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz",
+      "integrity": "sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg=="
     },
     "@types/request": {
       "version": "2.48.4",
@@ -81,38 +87,49 @@
       }
     },
     "acorn": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
     },
     "ansi-styles": {
@@ -377,12 +394,12 @@
       "dev": true
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
@@ -426,9 +443,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -487,6 +504,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "currently-unhandled": {
@@ -586,9 +611,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "encodeurl": {
@@ -617,47 +642,48 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.15.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.3.tgz",
-      "integrity": "sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.9.1",
+        "ajv": "^6.10.0",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^4.0.3",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.2.2",
-        "js-yaml": "^3.12.0",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
         "table": "^5.2.3",
-        "text-table": "^0.2.0"
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "debug": {
@@ -678,9 +704,9 @@
       }
     },
     "eslint-scope": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -688,12 +714,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -703,14 +729,14 @@
       "dev": true
     },
     "espree": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.7",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "esprima": {
@@ -720,9 +746,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -809,21 +835,6 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "finalhandler": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.2",
-            "statuses": "~1.4.0",
-            "unpipe": "~1.0.0"
-          }
-        },
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -852,6 +863,12 @@
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "send": {
@@ -928,14 +945,14 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -944,9 +961,9 @@
       "dev": true
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -969,6 +986,29 @@
       "requires": {
         "is-object": "~1.0.1",
         "merge-descriptors": "~1.0.0"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
+        }
       }
     },
     "find-up": {
@@ -1090,9 +1130,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1103,16 +1143,28 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "graceful-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
     "growl": {
@@ -1122,9 +1174,9 @@
       "dev": true
     },
     "grunt": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
-      "integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.1.0.tgz",
+      "integrity": "sha512-+NGod0grmviZ7Nzdi9am7vuRS/h76PcWDsV635mEXF0PEQMUV6Kb+OjTdsVxbi0PZmfQOjCMKb3w8CVZcqsn1g==",
       "dev": true,
       "requires": {
         "coffeescript": "~1.10.0",
@@ -1138,9 +1190,9 @@
         "grunt-legacy-log": "~2.0.0",
         "grunt-legacy-util": "~1.1.1",
         "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.13.0",
+        "js-yaml": "~3.13.1",
         "minimatch": "~3.0.2",
-        "mkdirp": "~0.5.1",
+        "mkdirp": "~1.0.3",
         "nopt": "~3.0.6",
         "path-is-absolute": "~1.0.0",
         "rimraf": "~2.6.2"
@@ -1171,6 +1223,12 @@
             "nopt": "~3.0.6",
             "resolve": "~1.1.0"
           }
+        },
+        "mkdirp": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+          "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
+          "dev": true
         },
         "resolve": {
           "version": "1.1.7",
@@ -1282,9 +1340,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
     "http-errors": {
@@ -1343,9 +1401,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -1383,47 +1441,91 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
     },
     "ipaddr.js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true
     },
     "is-arrayish": {
@@ -1432,20 +1534,32 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-object": {
       "version": "1.0.1",
@@ -1627,14 +1741,6 @@
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "merge-descriptors": {
@@ -1655,22 +1761,22 @@
       "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimatch": {
@@ -1683,9 +1789,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "ministyle": {
@@ -1712,12 +1818,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -1766,6 +1872,21 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "supports-color": {
@@ -1818,9 +1939,9 @@
       "integrity": "sha512-3Bxq1R5LBZp7fbFPZzFe5WN4s0q3+gxZaZuZVY+QctYJiCiVgXHOTIC0/HgZuOPFt/6BQcx5u0H2CUOxT/RoGQ=="
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "natural-compare": {
@@ -1869,13 +1990,15 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -1906,26 +2029,26 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "os-tmpdir": {
@@ -1970,12 +2093,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -2046,13 +2163,13 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.9.0"
+        "ipaddr.js": "1.9.1"
       }
     },
     "proxyquire": {
@@ -2160,9 +2277,9 @@
       }
     },
     "readable-stream": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-      "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2195,9 +2312,9 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2206,7 +2323,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -2216,7 +2333,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
@@ -2239,9 +2356,9 @@
       }
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -2254,12 +2371,12 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
@@ -2273,27 +2390,27 @@
       }
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2306,9 +2423,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
     "send": {
@@ -2389,6 +2506,14 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
       }
     },
     "soap": {
@@ -2490,13 +2615,25 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -2505,22 +2642,23 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
         "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        }
       }
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
@@ -2538,9 +2676,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
     "supports-color": {
@@ -2564,10 +2702,16 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
@@ -2579,15 +2723,6 @@
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -2619,19 +2754,12 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "trim-newlines": {
@@ -2641,9 +2769,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
     },
     "tunnel-agent": {
@@ -2667,6 +2795,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -2768,6 +2902,12 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -2821,10 +2961,10 @@
         "stack-trace": "0.0.x"
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0-alpha.1",
+  "version": "1.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@trayio/threadneedle": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@trayio/threadneedle/-/threadneedle-1.11.0.tgz",
-      "integrity": "sha512-fVdWZQjrdT6ys1jP24Mggjm5uJkdf58vGfeNGeI4y8B4ATlHx0OoV/84oxbZ6+4vB7Uyfsy2IQvsbzb2B/hxbg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@trayio/threadneedle/-/threadneedle-1.12.0.tgz",
+      "integrity": "sha512-RkE8ysV9KT+WjDxx6pHdPFeTiRsWP4FxiVvT7qnW5qZ2KDje9nbonSApBni/1yUjiIpUI/MiLbbewA/ik7zORg==",
       "requires": {
         "lodash": "~4.17.15",
         "mout": "~1.1.0",
@@ -56,9 +56,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
+      "version": "14.0.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
+      "integrity": "sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA=="
     },
     "@types/request": {
       "version": "2.48.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.1"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.1",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -56,9 +56,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.11.tgz",
-      "integrity": "sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg=="
+      "version": "14.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
+      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
     },
     "@types/request": {
       "version": "2.48.5",
@@ -93,9 +93,9 @@
       }
     },
     "acorn": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -277,9 +277,9 @@
       }
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
     "bluebird": {
@@ -735,22 +735,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -857,9 +857,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
-      "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "espree": {
@@ -1087,9 +1087,9 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -1657,9 +1657,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.2.0.tgz",
+      "integrity": "sha512-E0c4rPwr9ByePfNlTIB8z51kK1s2n6jrHuJeEHENl/sbq2G/S1auvibgEwNR4uSyiU+PiYHqSwsgGiXjG8p5ZQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -2386,9 +2386,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
     "object-keys": {
@@ -3114,28 +3114,6 @@
         "es-abstract": "^1.17.5"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
-      }
-    },
     "string.prototype.trimstart": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
@@ -3522,9 +3500,9 @@
       }
     },
     "winston": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+      "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "homepage": "https://github.com/trayio/falafel#readme",
   "dependencies": {
-    "@trayio/threadneedle": "~1.11.0",
+    "@trayio/threadneedle": "~1.12.0",
     "aws-sdk": "~2.413.0",
     "generate-schema": "~2.6.0",
     "lodash": "~4.17.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   },
   "devDependencies": {
     "body-parser": "~1.18.3",
-    "eslint": "~5.15.3",
+    "eslint": "~6.8.0",
     "express": "~4.16.4",
-    "grunt": "~1.0.4",
+    "grunt": "~1.1.0",
     "grunt-mocha-test": "~0.13.3",
     "mocha": "~5.2.0",
     "mocha-unfunk-reporter": "~0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0",
+  "version": "1.27.0-alpha.1",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0",
+  "version": "1.27.0-alpha.0",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {
@@ -24,7 +24,7 @@
     "@trayio/threadneedle": "~1.11.0",
     "aws-sdk": "~2.413.0",
     "generate-schema": "~2.6.0",
-    "lodash": "~4.17.15",
+    "lodash": "~4.17.19",
     "mime": "~2.4.4",
     "moment": "~2.24.0",
     "mout": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --exit test/**"
   },
   "author": "tray.io",
   "license": "MIT",
@@ -36,10 +36,12 @@
     "body-parser": "~1.18.3",
     "eslint": "~6.8.0",
     "express": "~4.16.4",
+    "fs-extra": "~9.0.1",
     "grunt": "~1.1.0",
     "grunt-mocha-test": "~0.13.3",
-    "mocha": "~5.2.0",
+    "mocha": "~7.2.0",
     "mocha-unfunk-reporter": "~0.4.0",
+    "nock": "~12.0.3",
     "proxyquire": "~2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0-alpha.0",
+  "version": "1.27.0",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0-alpha.1",
+  "version": "1.27.0",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {

--- a/rawHttpRequest.md
+++ b/rawHttpRequest.md
@@ -9,7 +9,23 @@ module.exports = {};
 
 Doing this will simply use the [default](#default-model) model configuration defined by falafel. Providing any Threadneedle REST configuration properties will be merged with the default configuration, giving `rawHttpRequest.js` precedence over the defaults.
 
-**NOTE:** the connector documentation for connectors which enabled Raw HTTP Request must indicate what the base URL will be if `endpoint` is used in the URL input. Additionally, any further configuration, such as authentication settings, need to be mentioned too.
+**NOTE:** the connector documentation for connectors which enable Raw HTTP Request must indicate what the base URL will be if `endpoint` is used in the URL input. Additionally, any further configuration, such as authentication settings, need to be mentioned too.
+
+### schemaOptions
+In addition to defining the model properties, a `schemaOptions` property is also available.
+
+#### url
+```js
+{
+	schemaOptions: {
+		url: 'all'
+	}
+}
+```
+
+- **all** (default) - provides both "Full URL" and "Endpoint" oneOf options for the URL
+- **endpointOnly** - provides only the "Endpoint" option in the oneOf
+- **fullOnly** - provides only the "Full URL" option in the oneOf
 
 
 ## Default Model

--- a/test/bindConnectors/bindTriggerRequest.js
+++ b/test/bindConnectors/bindTriggerRequest.js
@@ -426,7 +426,7 @@ describe('#bindTrigger', function () {
 			assert.deepEqual(
 				err.body,
 				{
-					code: '#trigger_ignore',
+					code: '#no_trigger',
 					message: 'Ignore this request.'
 				}
 			);

--- a/test/buildConnectorsJson/index.js
+++ b/test/buildConnectorsJson/index.js
@@ -1,10 +1,10 @@
-var _ = require('lodash');
-var assert = require('assert');
-var proxyquire = require('proxyquire');
+const _ = require('lodash');
+const assert = require('assert');
+const proxyquire = require('proxyquire');
 
-var fileOutput;
+let fileOutput;
 
-var buildConnectorsJson = proxyquire(
+const buildConnectorsJson = proxyquire(
 	'../../lib/buildConnectorsJson',
 	{
 		fs: {
@@ -17,7 +17,7 @@ var buildConnectorsJson = proxyquire(
 
 describe('#buildConnectorsJson', function () {
 
-	var exampleConfig = {
+	const exampleConfig = {
 		name: 'mailchimp',
 		title: 'MailChimp',
 		icon: {
@@ -32,9 +32,9 @@ describe('#buildConnectorsJson', function () {
 
 	it('should pick the top level connectors keys', function () {
 
-		var inputConfig = _.cloneDeep(exampleConfig);
+		const inputConfig = _.cloneDeep(exampleConfig);
 
-		var outputJsonString = buildConnectorsJson(null, [inputConfig]);
+		const outputJsonString = buildConnectorsJson(null, [inputConfig]);
 
 		assert.deepEqual(
 			_.defaults(
@@ -54,7 +54,7 @@ describe('#buildConnectorsJson', function () {
 
 	it('should validate `branches` property', function () {
 
-		var inputConfig = _.cloneDeep(exampleConfig);
+		const inputConfig = _.cloneDeep(exampleConfig);
 		inputConfig.branches = [
 			{
 				name: 'test',
@@ -66,7 +66,7 @@ describe('#buildConnectorsJson', function () {
 			},
 		];
 
-		var outputJsonString = buildConnectorsJson(null, [inputConfig]);
+		const outputJsonString = buildConnectorsJson(null, [inputConfig]);
 
 		assert.deepEqual(
 			_.defaults(
@@ -92,7 +92,7 @@ describe('#buildConnectorsJson', function () {
 			outputJsonString[0]
 		);
 
-		var invalidInputConfig = _.cloneDeep(exampleConfig);
+		const invalidInputConfig = _.cloneDeep(exampleConfig);
 		invalidInputConfig.branches = [
 			{
 				name: 'test',
@@ -121,14 +121,14 @@ describe('#buildConnectorsJson', function () {
 
 	});
 
-	it('should not add messages without schemas', function () {
+	it('should not add operations without schemas', function () {
 
-		var outputJsonString = buildConnectorsJson(null, [
+		const outputJsonString = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					messages: [
 						{
-							name: 'my_message',
+							name: 'my_operation',
 							model: {
 								url: '..'
 							}
@@ -143,14 +143,14 @@ describe('#buildConnectorsJson', function () {
 
 	});
 
-	it('should not add messages which start with \'#\' in their name', function () {
+	it('should not add operations which start with \'#\' in their name', function () {
 
-		var outputJsonString = buildConnectorsJson(null, [
+		const outputJsonString = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					messages: [
 						{
-							name: '#my_message',
+							name: '#my_operation',
 							model: {
 								url: '..'
 							},
@@ -168,14 +168,14 @@ describe('#buildConnectorsJson', function () {
 
 	});
 
-	it('should add messages with schemas', function () {
+	it('should add operations with schemas (as public, if type is not defined)', function () {
 
-		var outputJsonString = buildConnectorsJson(null, [
+		const outputJsonString = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					messages: [
 						{
-							name: 'my_message',
+							name: 'my_operation',
 							model: {
 								url: '..'
 							},
@@ -197,15 +197,107 @@ describe('#buildConnectorsJson', function () {
 
 	});
 
-	it('should autogenerate message titles nicely if not already declared', function () {
+	it('should add operations with schemas with type \'public\'', function () {
 
-		var outputJsonString = buildConnectorsJson(null, [
+		const outputJsonString = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							name: 'my_operation',
+							model: {
+								url: '..'
+							},
+							schema: {
+								type: 'public',
+								input: {
+									name: {
+										type: 'string'
+									}
+								}
+							}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.equal(outputJsonString[0].messages.length, 1);
+		assert.equal(outputJsonString[0].messages[0].type, 'public');
+
+	});
+
+	it('should add operations with schemas with type \'ddl\'', function () {
+
+		const outputJsonString = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							name: 'my_operation_ddl',
+							model: {
+								url: '..'
+							},
+							schema: {
+								type: 'ddl',
+								input: {
+									name: {
+										type: 'string'
+									}
+								}
+							}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.equal(outputJsonString[0].messages.length, 1);
+		assert.equal(outputJsonString[0].messages[0].type, 'ddl');
+
+	});
+
+	it('should not add operations with schemas with type \'private\'', function () {
+
+		const outputJsonString = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							name: 'my_operation',
+							model: {
+								url: '..'
+							},
+							schema: {
+								type: 'private',
+								input: {
+									name: {
+										type: 'string'
+									}
+								}
+							}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.equal(outputJsonString[0].messages.length, 0);
+
+	});
+
+	it('should autogenerate operation titles nicely if not already declared', function () {
+
+		const parsedJsonSchema = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					messages: [
 						{
 							schema: {
-								name: 'my_message',
+								name: 'my_operation',
 								input: {
 									name: {
 										type: 'string'
@@ -219,8 +311,8 @@ describe('#buildConnectorsJson', function () {
 						},
 						{
 							schema: {
-								name: 'my_second_message',
-								title: 'My amazing second message',
+								name: 'my_second_operation',
+								title: 'My amazing second operation',
 								delivery: 'request_response',
 							},
 							model: {}
@@ -231,26 +323,24 @@ describe('#buildConnectorsJson', function () {
 			)
 		]);
 
-		var parsedJsonSchema = outputJsonString;
-
 		assert.equal(parsedJsonSchema[0].messages.length, 2);
 		// remember - operations are sorted by title
-		assert.equal(parsedJsonSchema[0].messages[1].title, 'My message');
+		assert.equal(parsedJsonSchema[0].messages[1].title, 'My operation');
 		assert.equal(parsedJsonSchema[0].messages[1].delivery, 'acknowledge');
-		assert.equal(parsedJsonSchema[0].messages[0].title, 'My amazing second message');
+		assert.equal(parsedJsonSchema[0].messages[0].title, 'My amazing second operation');
 		assert.equal(parsedJsonSchema[0].messages[0].delivery, 'request_response');
 
 	});
-	
-	it('should autogenerate message titles which include id, ids or url nicely if not already declared', function () {
 
-		var outputJsonString = buildConnectorsJson(null, [
+	it('should autogenerate operation titles which include id, ids or url nicely if not already declared', function () {
+
+		const parsedJsonSchema = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					messages: [
 						{
 							schema: {
-								name: 'my_message_id',
+								name: 'my_operation_id',
 								input: {
 									name: {
 										type: 'string'
@@ -264,22 +354,22 @@ describe('#buildConnectorsJson', function () {
 						},
 						{
 							schema: {
-								name: 'my_second_message_ids',
+								name: 'my_second_operation_ids',
 								delivery: 'request_response',
 							},
 							model: {}
 						},
 						{
 							schema: {
-								name: 'my_third_message_url',
+								name: 'my_third_operation_url',
 								delivery: 'request_response',
 							},
 							model: {}
 						},
 						{
 							schema: {
-								name: 'my_fourth_message_url',
-								title: 'My Amazing 4th message',
+								name: 'my_fourth_operation_url',
+								title: 'My Amazing 4th operation',
 								delivery: 'request_response',
 							},
 							model: {}
@@ -290,29 +380,246 @@ describe('#buildConnectorsJson', function () {
 			)
 		]);
 
-		var parsedJsonSchema = outputJsonString;
 		assert.equal(parsedJsonSchema[0].messages.length, 4);
 		// remember - operations are sorted by title
-		assert.equal(parsedJsonSchema[0].messages[0].title, 'My Amazing 4th message');
+		assert.equal(parsedJsonSchema[0].messages[0].title, 'My Amazing 4th operation');
 		assert.equal(parsedJsonSchema[0].messages[0].delivery, 'request_response');
-		assert.equal(parsedJsonSchema[0].messages[1].title, 'My message ID');
+		assert.equal(parsedJsonSchema[0].messages[1].title, 'My operation ID');
 		assert.equal(parsedJsonSchema[0].messages[1].delivery, 'acknowledge');
-		assert.equal(parsedJsonSchema[0].messages[2].title, 'My second message IDs');
+		assert.equal(parsedJsonSchema[0].messages[2].title, 'My second operation IDs');
 		assert.equal(parsedJsonSchema[0].messages[2].delivery, 'request_response');
-		assert.equal(parsedJsonSchema[0].messages[3].title, 'My third message URL');
+		assert.equal(parsedJsonSchema[0].messages[3].title, 'My third operation URL');
 		assert.equal(parsedJsonSchema[0].messages[3].delivery, 'request_response');
 
 	});
 
-	it('should create from specified output schema if specified', function () {
+	it('should define `public` type for operations with schemas', function () {
 
-		var outputJsonString = buildConnectorsJson(null, [
+		const parsedJsonSchema = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					messages: [
 						{
 							schema: {
-								name: 'my_message',
+								name: 'my_operation',
+								input: {
+									name: {
+										type: 'string'
+									}
+								},
+								delivery: 'acknowledge'
+							},
+							model: {
+								url: '..'
+							}
+						},
+						{
+							schema: {
+								name: 'my_second_operation',
+								title: 'My amazing second operation',
+								delivery: 'request_response',
+							},
+							model: {}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.equal(parsedJsonSchema[0].messages.length, 2);
+		assert.equal(parsedJsonSchema[0].messages[0].type, 'public');
+		assert.equal(parsedJsonSchema[0].messages[1].type, 'public');
+
+	});
+
+	it('should define `ddl` type for operations whose name ends with `_ddl`', function () {
+		const parsedJsonSchema = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							schema: {
+								name: 'my_operation',
+								input: {
+									name: {
+										type: 'string'
+									}
+								},
+							},
+							model: {
+								url: '..'
+							}
+						},
+						{
+							name: 'my_operation_ddl',
+							model: {}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.equal(parsedJsonSchema[0].messages.length, 2);
+		assert.equal(parsedJsonSchema[0].messages[0].type, 'public');
+		assert.equal(parsedJsonSchema[0].messages[1].type, 'ddl');
+	});
+
+	it('should create generic schema for `ddl` type if schema is not provided', function () {
+		const parsedJsonSchema = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							name: 'my_operation_ddl',
+							model: {}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.equal(parsedJsonSchema[0].messages.length, 1);
+		assert.equal(parsedJsonSchema[0].messages[0].type, 'ddl');
+		assert.deepEqual(
+			parsedJsonSchema[0].messages[0].input_schema,
+			{
+				'$schema': 'http://json-schema.org/draft-04/schema#',
+				'additionalProperties': false,
+				'advanced': [],
+				'properties': {},
+				'required': [],
+				'type': 'object',
+			}
+		);
+	});
+
+	it('should use schema for `ddl` type if schema is provided', function () {
+		const parsedJsonSchema = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							name: 'my_operation_ddl',
+							model: {},
+							schema: {
+								input: {
+									dependant_property: {
+										type: 'string',
+										required: true
+									}
+								},
+							}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.equal(parsedJsonSchema[0].messages.length, 1);
+		assert.equal(parsedJsonSchema[0].messages[0].type, 'ddl');
+		assert.deepEqual(
+			parsedJsonSchema[0].messages[0].input_schema,
+			{
+				'$schema': 'http://json-schema.org/draft-04/schema#',
+				'additionalProperties': false,
+				'advanced': [],
+				'properties': {
+					dependant_property: {
+						title: 'Dependant property',
+						type: 'string'
+					}
+				},
+				'required': ['dependant_property'],
+				'type': 'object',
+			}
+		);
+	});
+
+	it('should not include certain properties for `ddl` type if schema is provided', function () {
+		const parsedJsonSchema = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							name: 'my_operation_ddl',
+							model: {},
+							schema: {
+								helpLink: 'something',
+								delivery: 'acknowledge',
+								default: true,
+								timeoutMillis: 500,
+								input: {
+									dependant_property: {
+										type: 'string',
+										required: true
+									}
+								},
+								reply: {
+									test: {
+										type: 'string'
+									}
+								},
+							}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.strictEqual(parsedJsonSchema[0].messages.length, 1);
+		assert.strictEqual(parsedJsonSchema[0].messages[0].type, 'ddl');
+		const ddlOp = parsedJsonSchema[0].messages[0];
+		assert.strictEqual(ddlOp.default, undefined);
+		assert.strictEqual(ddlOp.delivery, undefined);
+		assert.strictEqual(ddlOp.helpLink, undefined);
+		assert.strictEqual(ddlOp.timeoutMillis, undefined);
+		assert.strictEqual(ddlOp.reply_schema, undefined);
+	});
+
+	it('should error if title for `ddl` type does not end with ` DDL`', function () {
+		try {
+			const parsedJsonSchema = buildConnectorsJson(null, [
+				_.defaults(
+					{
+						messages: [
+							{
+								name: 'my_operation_ddl',
+								model: {},
+								schema: {
+									title: 'My operation',
+									input: {
+										dependant_property: {
+											type: 'string',
+											required: true
+										}
+									}
+								}
+							}
+						]
+					},
+					exampleConfig
+				)
+			]);
+			assert.fail(parsedJsonSchema);
+		} catch (buildConnectorsJsonError) {
+			assert.strictEqual(buildConnectorsJsonError.message, 'DDL operation titles must end with `DDL` suffix; my_operation_ddl');
+			assert.strictEqual(buildConnectorsJsonError.code, '#connector_error');
+		}
+	});
+
+	it('should create from specified output schema if specified', function () {
+		const parsedJsonSchema = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							schema: {
+								name: 'my_operation',
 								input: {
 									name: {
 										type: 'string'
@@ -334,22 +641,18 @@ describe('#buildConnectorsJson', function () {
 			)
 		]);
 
-		var parsedJsonSchema = outputJsonString;
-
 		assert(_.isPlainObject(parsedJsonSchema[0].messages[0].output_schema));
 		assert.equal(parsedJsonSchema[0].messages[0].output_schema.properties.result.type, 'integer');
-
 	});
 
 	it('should generate from sample response if specified', function () {
-
-		var outputJsonString = buildConnectorsJson(null, [
+		const parsedJsonSchema = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					messages: [
 						{
 							schema: {
-								name: 'my_message',
+								name: 'my_operation',
 								input: {
 									name: {
 										type: 'string'
@@ -369,16 +672,12 @@ describe('#buildConnectorsJson', function () {
 			)
 		]);
 
-		var parsedJsonSchema = outputJsonString;
-
 		assert(_.isObject(parsedJsonSchema[0].messages[0].output_schema));
 		assert.equal(parsedJsonSchema[0].messages[0].output_schema.properties.result.type, 'boolean');
-
 	});
 
 	it('should add global schema input if declared', function () {
-
-		var outputJsonString = buildConnectorsJson(null, [
+		const parsedJsonSchema = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					globalSchema: {
@@ -392,7 +691,7 @@ describe('#buildConnectorsJson', function () {
 					},
 					messages: [
 						{
-							name: 'my_message',
+							name: 'my_operation',
 							schema: {
 								input: {
 									name: {
@@ -410,20 +709,16 @@ describe('#buildConnectorsJson', function () {
 			)
 		]);
 
-		var parsedJsonSchema = outputJsonString;
-
 		assert.equal(_.keys(parsedJsonSchema[0].messages[0].input_schema.properties).length, 2);
 		assert.equal(parsedJsonSchema[0].messages[0].input_schema.properties.api_key.type, 'string');
 		assert.equal(parsedJsonSchema[0].messages[0].input_schema.properties.name.type, 'string');
 		assert.equal(parsedJsonSchema[0].messages.length, 1);
-
 	});
 
 	it('should add global auth scopes if not declared on a local level', function () {
+		const scopeArray = [ 'test_scope', 'another_scope' ];
 
-		var scopeArray = [ 'test_scope', 'another_scope' ];
-
-		var outputJsonString = buildConnectorsJson(null, [
+		const parsedJsonSchema = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					globalSchema: {
@@ -432,7 +727,7 @@ describe('#buildConnectorsJson', function () {
 					},
 					messages: [
 						{
-							name: 'my_message',
+							name: 'my_operation',
 							schema: {
 								input: {
 									name: {
@@ -450,17 +745,14 @@ describe('#buildConnectorsJson', function () {
 			)
 		]);
 
-		var parsedJsonSchema = outputJsonString;
-
 		assert.deepEqual(parsedJsonSchema[0].messages[0].auth_scopes, scopeArray);
-
 	});
 
 	it('should not create file if `directory` is not a string', function () {
 
-		var inputConfig = _.cloneDeep(exampleConfig);
+		const inputConfig = _.cloneDeep(exampleConfig);
 
-		var outputJsonString = buildConnectorsJson(null, [
+		const outputJsonString = buildConnectorsJson(null, [
 			_.defaults(
 				{
 					globalSchema: {
@@ -474,9 +766,9 @@ describe('#buildConnectorsJson', function () {
 					},
 					messages: [
 						{
-							name: 'my_message',
+							name: 'my_operation',
 							schema: {
-								title: 'My Message',
+								title: 'My operation',
 								input: {
 									name: {
 										type: 'string'
@@ -499,9 +791,9 @@ describe('#buildConnectorsJson', function () {
 
 	it('should create file if `directory` is a string', function () {
 
-		var inputConfig = _.cloneDeep(exampleConfig);
+		const inputConfig = _.cloneDeep(exampleConfig);
 
-		var outputJsonString = buildConnectorsJson('meh', [
+		const outputJsonString = buildConnectorsJson('meh', [
 			_.defaults(
 				{
 					globalSchema: {
@@ -515,9 +807,9 @@ describe('#buildConnectorsJson', function () {
 					},
 					messages: [
 						{
-							name: 'my_message',
+							name: 'my_operation',
 							schema: {
-								title: 'My Message',
+								title: 'My operation',
 								input: {
 									name: {
 										type: 'string'
@@ -534,7 +826,7 @@ describe('#buildConnectorsJson', function () {
 			)
 		]);
 
-		var parsedJsonSchema = JSON.parse(fileOutput);
+		const parsedJsonSchema = JSON.parse(fileOutput);
 
 		assert.deepEqual(
 			parsedJsonSchema,
@@ -544,7 +836,8 @@ describe('#buildConnectorsJson', function () {
 						icon: _.pick(inputConfig.icon, [ 'value', 'type' ]),
 						messages: [
 							{
-								title: 'My Message',
+								title: 'My operation',
+								type: 'public',
 								input_schema: {
 									type: 'object',
 									properties: {

--- a/test/buildConnectorsJson/index.js
+++ b/test/buildConnectorsJson/index.js
@@ -52,6 +52,62 @@ describe('#buildConnectorsJson', function () {
 
 	});
 
+	it('should have name for all operation variants', function () {
+		const outputJsonString = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							name: 'my_operation',
+							model: {
+								url: '..'
+							},
+							schema: {
+								input: {
+									name: {
+										type: 'string'
+									}
+								}
+							}
+						},
+						{
+							name: 'my_private_operation',
+							model: {
+								url: '..'
+							}
+						},
+						{
+							name: 'my_operation_ddl',
+							model: {
+								url: '..'
+							},
+							schema: {
+								type: 'ddl',
+								input: {
+									name: {
+										type: 'string'
+									}
+								}
+							}
+						},
+						{
+							name: 'my_operation_two_ddl',
+							model: {
+								url: '..'
+							}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.equal(outputJsonString[0].messages.length, 3);
+		assert.equal(outputJsonString[0].messages[0].name, 'my_operation');
+		assert.equal(outputJsonString[0].messages[1].name, 'my_operation_ddl');
+		assert.equal(outputJsonString[0].messages[2].name, 'my_operation_two_ddl');
+	});
+
 	it('should validate `branches` property', function () {
 
 		const inputConfig = _.cloneDeep(exampleConfig);
@@ -121,7 +177,7 @@ describe('#buildConnectorsJson', function () {
 
 	});
 
-	it('should not add operations without schemas', function () {
+	it('should not add private operations (non-ddl ops without schemas)', function () {
 
 		const outputJsonString = buildConnectorsJson(null, [
 			_.defaults(
@@ -482,6 +538,7 @@ describe('#buildConnectorsJson', function () {
 		]);
 
 		assert.equal(parsedJsonSchema[0].messages.length, 1);
+		assert.equal(parsedJsonSchema[0].messages[0].name, 'my_operation_ddl');
 		assert.equal(parsedJsonSchema[0].messages[0].type, 'ddl');
 		assert.deepEqual(
 			parsedJsonSchema[0].messages[0].input_schema,
@@ -836,6 +893,7 @@ describe('#buildConnectorsJson', function () {
 						icon: _.pick(inputConfig.icon, [ 'value', 'type' ]),
 						messages: [
 							{
+								name: 'my_operation',
 								title: 'My operation',
 								type: 'public',
 								input_schema: {

--- a/test/buildConnectorsJson/prettyTitle.js
+++ b/test/buildConnectorsJson/prettyTitle.js
@@ -5,46 +5,55 @@ var prettyTitle = require('../../lib/buildConnectorsJson/prettyTitle');
 
 describe('#prettyTitle', function () {
 
-	it('should make things look nice', function () {
-		assert.equal(prettyTitle('list_name'), 'List name');
-		assert.equal(prettyTitle('list-name'), 'List name');
-		assert.equal(prettyTitle('listName'), 'List name');
-		assert.equal(prettyTitle('ListName'), 'List name');
-		assert.equal(prettyTitle('listName'), 'List name');
+	it('should make names look nice', function () {
+		assert.strictEqual(prettyTitle('list_name'), 'List name');
+		assert.strictEqual(prettyTitle('list-name'), 'List name');
+		assert.strictEqual(prettyTitle('listName'), 'List name');
+		assert.strictEqual(prettyTitle('ListName'), 'List name');
+		assert.strictEqual(prettyTitle('listName'), 'List name');
 	});
 
 	it('should upper case id', function () {
-		assert.equal(prettyTitle('id'), 'ID');
-		assert.equal(prettyTitle('list_id'), 'List ID');
-		assert.equal(prettyTitle('list_id_name'), 'List ID name');
+		assert.strictEqual(prettyTitle('id'), 'ID');
+		assert.strictEqual(prettyTitle('list_id'), 'List ID');
+		assert.strictEqual(prettyTitle('list_id_name'), 'List ID name');
 
-		assert.equal(prettyTitle('lid'), 'Lid');
-		assert.equal(prettyTitle('list baseid'), 'List baseid');
+		assert.strictEqual(prettyTitle('lid'), 'Lid');
+		assert.strictEqual(prettyTitle('list baseid'), 'List baseid');
 	});
 
 	it('should upper case ids', function () {
-		assert.equal(prettyTitle('ids'), 'IDs');
-		assert.equal(prettyTitle('list_ids'), 'List IDs');
-		assert.equal(prettyTitle('list_ids_name'), 'List IDs name');
+		assert.strictEqual(prettyTitle('ids'), 'IDs');
+		assert.strictEqual(prettyTitle('list_ids'), 'List IDs');
+		assert.strictEqual(prettyTitle('list_ids_name'), 'List IDs name');
 
-		assert.equal(prettyTitle('lids'), 'Lids');
-		assert.equal(prettyTitle('list baseids'), 'List baseids');
+		assert.strictEqual(prettyTitle('lids'), 'Lids');
+		assert.strictEqual(prettyTitle('list baseids'), 'List baseids');
 	});
 
 	it('should upper case url', function () {
-		assert.equal(prettyTitle('url'), 'URL');
-		assert.equal(prettyTitle('list_url'), 'List URL');
-		assert.equal(prettyTitle('list_url_name'), 'List URL name');
+		assert.strictEqual(prettyTitle('url'), 'URL');
+		assert.strictEqual(prettyTitle('list_url'), 'List URL');
+		assert.strictEqual(prettyTitle('list_url_name'), 'List URL name');
 
-		assert.equal(prettyTitle('lurl'), 'Lurl');
-		assert.equal(prettyTitle('list baseurl'), 'List baseurl');
+		assert.strictEqual(prettyTitle('lurl'), 'Lurl');
+		assert.strictEqual(prettyTitle('list baseurl'), 'List baseurl');
+	});
+
+	it('should upper case ddl', function () {
+		assert.strictEqual(prettyTitle('ddl'), 'DDL');
+		assert.strictEqual(prettyTitle('list_ddl'), 'List DDL');
+
+		assert.strictEqual(prettyTitle('abcddl'), 'Abcddl');
+		assert.strictEqual(prettyTitle('list abcddl'), 'List abcddl');
 	});
 
 	it('should globally upper case id, ids and url', function () {
-		assert.equal(prettyTitle('list_id_url_name'), 'List ID URL name');
-		assert.equal(prettyTitle('list_url_id_name'), 'List URL ID name');
-		assert.equal(prettyTitle('list_ids_url_name'), 'List IDs URL name');
-		assert.equal(prettyTitle('list_url_ids_name'), 'List URL IDs name');
+		assert.strictEqual(prettyTitle('list_id_url_name'), 'List ID URL name');
+		assert.strictEqual(prettyTitle('list_url_id_name'), 'List URL ID name');
+		assert.strictEqual(prettyTitle('list_ids_url_name'), 'List IDs URL name');
+		assert.strictEqual(prettyTitle('list_url_ids_name'), 'List URL IDs name');
+		assert.strictEqual(prettyTitle('list_url_ids_name_ddl'), 'List URL IDs name DDL');
 	});
 
 });

--- a/test/falafel.js
+++ b/test/falafel.js
@@ -59,6 +59,61 @@ describe('falafel', function () {
 		assert.strictEqual(called, false);
 	});
 
+	it('should not spin up express server in dev mode with env var set', function () {
+		process.env.FALAFEL_DISABLE_DEV_SERVER = 'true';
+		var called = false;
+
+		var Falafel = proxyquire('../lib', {
+			'./buildConnectorsJson': function () {},
+			'./devServer': function () {
+				called = true;
+			}
+		});
+
+		new Falafel().wrap({
+			directory: __dirname+'/sample',
+			dev: true
+		});
+		delete process.env.FALAFEL_DISABLE_DEV_SERVER;
+		assert.strictEqual(called, false);
+	});
+
+	it('should not spin up express server in dev mode with flag set', function () {
+		var called = false;
+
+		var Falafel = proxyquire('../lib', {
+			'./buildConnectorsJson': function () {},
+			'./devServer': function () {
+				called = true;
+			}
+		});
+
+		new Falafel().wrap({
+			directory: __dirname+'/sample',
+			dev: true,
+			disableDevServer: true
+		});
+		assert.strictEqual(called, false);
+	});
+
+	it('should spin up express server in dev mode with no env var set', function () {
+		var called = false;
+
+		var Falafel = proxyquire('../lib', {
+			'./buildConnectorsJson': function () {},
+			'./devServer': function () {
+				called = true;
+			}
+		});
+
+		new Falafel().wrap({
+			directory: __dirname+'/sample',
+			dev: true
+		});
+		assert(called);
+	});
+
+
 	it('should return JSON schema for generateJsonSchema method', function () {
 
 		var jsonSchema = new Falafel().generateJsonSchema({

--- a/test/fileHandler/index_test.js
+++ b/test/fileHandler/index_test.js
@@ -1,0 +1,1956 @@
+const assert = require('assert');
+const util = require('util');
+const stream = require('stream');
+
+const _  = require('lodash');
+const guid = require('mout/random/guid');
+const fs = require('fs-extra');
+const proxyquire = require('proxyquire');
+const nock = require('nock');
+const needle = require('needle');
+const moment = require('moment');
+
+function getProxiedFileHandler (proxyModules = {}, options = {}) {
+	const fileHandler = proxyquire(
+		'../../lib/fileHandler/index.js',
+		{
+			'aws-sdk': {
+				config: {
+					update: (...args) => {
+						assert.fail(args);
+					}
+				},
+				'S3': class S3 {
+					constructor (...args) {
+						assert.fail(args);
+					}
+					upload (args) {
+						assert.fail(...args);
+					}
+					getSignedUrl (...args) {
+						assert.fail(args);
+					}
+				}
+			},
+			...proxyModules
+		}
+	);
+	fileHandler(options);
+}
+
+describe('#fileHandler', function () {
+	function beforeEachFunc () {
+		global.falafel = {};
+	}
+	function afterEachFunc () {
+		delete global.falafel;
+	}
+
+	describe('upload', () => {
+
+		const testFilePath = '/tmp/falafel/tests/example.txt';
+		const contentLength = Buffer.byteLength('Example content', 'utf8');
+		before(() => {
+			fs.ensureFileSync(testFilePath);
+			fs.writeFileSync(testFilePath, 'Example content');
+		});
+		after(() => {
+			fs.unlink(testFilePath);
+		});
+
+		beforeEach(beforeEachFunc);
+		afterEach(afterEachFunc);
+
+		it(`should upload file from source path`, async () => {
+			const testFilePath = '/tmp/falafel/tests/example.txt';
+			fs.ensureFileSync(testFilePath);
+			fs.writeFileSync(testFilePath, 'Example content');
+			const contentLength = Buffer.byteLength('Example content', 'utf8');
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-2' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.deepEqual(uploadOptions, {});
+							assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+							assert.strictEqual(uploadParams.ContentLength, contentLength);
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(null, {
+								Bucket: uploadParams.Bucket,
+								Key: uploadParams.Key,
+							});
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							currentTime = moment();
+							assert.strictEqual(operation, 'getObject');
+							assert.strictEqual(signedParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(signedParams.Key, randomGuid);
+							assert.strictEqual(signedParams.Expires, 21600);
+							callback(null, 'https://test.aws.com/buckethash');
+						}
+					}
+				}
+			});
+
+			const uploadResult = await falafel.files.upload({
+				contentType: 'text/plain',
+				name: 'example.txt',
+				length: contentLength,
+				file: testFilePath
+			});
+
+			assert.strictEqual(uploadResult.name, 'example.txt');
+			assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+			assert.strictEqual(uploadResult.mime_type, 'text/plain');
+			assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+		});
+
+		it(`should upload file to dev bucket in dev mode`, async () => {
+			const testFilePath = '/tmp/falafel/tests/example.txt';
+			fs.ensureFileSync(testFilePath);
+			fs.writeFileSync(testFilePath, 'Example content');
+			const contentLength = Buffer.byteLength('Example content', 'utf8');
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler(
+				{
+					'mout/random/guid': () => {
+						return randomGuid;
+					},
+					'aws-sdk': {
+						'S3': class S3 {
+							constructor (params) {
+								assert.deepEqual(
+									params,
+									{ region: 'us-west-2' }
+								);
+							}
+							async upload (uploadParams, uploadOptions,  callback) {
+								assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads-dev');
+								assert.strictEqual(uploadParams.Key, randomGuid);
+								assert.strictEqual(uploadParams.ContentType, 'text/plain');
+								assert.strictEqual(uploadParams.ContentLength, contentLength);
+								assert(_.isFunction(uploadParams.Body.pipe));
+								const streamContent = await new Promise((resolve, reject) => {
+									let acc = '';
+									uploadParams.Body.on('data', (chunk) => {
+										acc += chunk.toString();
+									});
+									uploadParams.Body.on('end', (chunk) => {
+										if (chunk) {
+											acc += chunk.toString();
+										}
+										resolve(acc);
+									});
+									uploadParams.Body.on('error', reject);
+								});
+								assert.strictEqual(streamContent, 'Example content');
+								callback(null, {
+									Bucket: uploadParams.Bucket,
+									Key: uploadParams.Key,
+								});
+							}
+							getSignedUrl (operation, signedParams, callback) {
+								currentTime = moment();
+								assert.strictEqual(operation, 'getObject');
+								assert.strictEqual(signedParams.Bucket, 'workflow-file-uploads-dev');
+								assert.strictEqual(signedParams.Key, randomGuid);
+								assert.strictEqual(signedParams.Expires, 21600);
+								callback(null, 'https://test.aws.com/buckethash');
+							}
+						}
+					}
+				},
+				{
+					dev: true
+				}
+			);
+
+			const uploadResult = await falafel.files.upload({
+				contentType: 'text/plain',
+				name: 'example.txt',
+				length: contentLength,
+				file: testFilePath
+			});
+
+			assert.strictEqual(uploadResult.name, 'example.txt');
+			assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+			assert.strictEqual(uploadResult.mime_type, 'text/plain');
+			assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+		});
+
+		it(`should override default bucket and region if specified`, async () => {
+			const testFilePath = '/tmp/falafel/tests/example.txt';
+			fs.ensureFileSync(testFilePath);
+			fs.writeFileSync(testFilePath, 'Example content');
+			const contentLength = Buffer.byteLength('Example content', 'utf8');
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-1' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.deepEqual(uploadOptions, {});
+							assert.strictEqual(uploadParams.Bucket, 'other-bucket');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+							assert.strictEqual(uploadParams.ContentLength, contentLength);
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(null, {
+								Bucket: uploadParams.Bucket,
+								Key: uploadParams.Key,
+							});
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							currentTime = moment();
+							assert.strictEqual(operation, 'getObject');
+							assert.strictEqual(signedParams.Bucket, 'other-bucket');
+							assert.strictEqual(signedParams.Key, randomGuid);
+							assert.strictEqual(signedParams.Expires, 21600);
+							callback(null, 'https://test.aws.com/buckethash');
+						}
+					}
+				}
+			});
+
+			const uploadResult = await falafel.files.upload({
+				bucket: 'other-bucket',
+				region: 'us-west-1',
+				contentType: 'text/plain',
+				name: 'example.txt',
+				length: contentLength,
+				file: testFilePath
+			});
+
+			assert.strictEqual(uploadResult.name, 'example.txt');
+			assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+			assert.strictEqual(uploadResult.mime_type, 'text/plain');
+			assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+		});
+
+		it(`should override default bucket and region if specified in environment`, async () => {
+			const testFilePath = '/tmp/falafel/tests/example.txt';
+			fs.ensureFileSync(testFilePath);
+			fs.writeFileSync(testFilePath, 'Example content');
+			const contentLength = Buffer.byteLength('Example content', 'utf8');
+
+			process.env.CONNECTOR_FILE_BUCKET = 'other-bucket';
+			process.env.CONNECTOR_FILE_REGION = 'us-west-1';
+
+			try {
+				const randomGuid = guid();
+				let currentTime;
+				getProxiedFileHandler({
+					'mout/random/guid': () => {
+						return randomGuid;
+					},
+					'aws-sdk': {
+						'S3': class S3 {
+							constructor (params) {
+								assert.deepEqual(
+									params,
+									{ region: 'us-west-1' }
+								);
+							}
+							async upload (uploadParams, uploadOptions, callback) {
+								assert.deepEqual(uploadOptions, {});
+								assert.strictEqual(uploadParams.Bucket, 'other-bucket');
+								assert.strictEqual(uploadParams.Key, randomGuid);
+								assert.strictEqual(uploadParams.ContentType, 'text/plain');
+								assert.strictEqual(uploadParams.ContentLength, contentLength);
+								assert(_.isFunction(uploadParams.Body.pipe));
+								const streamContent = await new Promise((resolve, reject) => {
+									let acc = '';
+									uploadParams.Body.on('data', (chunk) => {
+										acc += chunk.toString();
+									});
+									uploadParams.Body.on('end', (chunk) => {
+										if (chunk) {
+											acc += chunk.toString();
+										}
+										resolve(acc);
+									});
+									uploadParams.Body.on('error', reject);
+								});
+								assert.strictEqual(streamContent, 'Example content');
+								callback(null, {
+									Bucket: uploadParams.Bucket,
+									Key: uploadParams.Key,
+								});
+							}
+							getSignedUrl (operation, signedParams, callback) {
+								currentTime = moment();
+								assert.strictEqual(operation, 'getObject');
+								assert.strictEqual(signedParams.Bucket, 'other-bucket');
+								assert.strictEqual(signedParams.Key, randomGuid);
+								assert.strictEqual(signedParams.Expires, 21600);
+								callback(null, 'https://test.aws.com/buckethash');
+							}
+						}
+					}
+				});
+
+				const uploadResult = await falafel.files.upload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					length: contentLength,
+					file: testFilePath
+				});
+
+				assert.strictEqual(uploadResult.name, 'example.txt');
+				assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+				assert.strictEqual(uploadResult.mime_type, 'text/plain');
+				assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+			} finally {
+				delete process.env.CONNECTOR_FILE_BUCKET;
+				delete process.env.CONNECTOR_FILE_REGION;
+			}
+		});
+
+		it(`should override default dev bucket in dev mode if specified in environment`, async () => {
+			const testFilePath = '/tmp/falafel/tests/example.txt';
+			fs.ensureFileSync(testFilePath);
+			fs.writeFileSync(testFilePath, 'Example content');
+			const contentLength = Buffer.byteLength('Example content', 'utf8');
+
+			process.env.CONNECTOR_FILE_DEV_BUCKET = 'other-dev-bucket';
+			try {
+				const randomGuid = guid();
+				let currentTime;
+				getProxiedFileHandler(
+					{
+						'mout/random/guid': () => {
+							return randomGuid;
+						},
+						'aws-sdk': {
+							'S3': class S3 {
+								constructor (params) {
+									assert.deepEqual(
+										params,
+										{ region: 'us-west-2' }
+									);
+								}
+								async upload (uploadParams, uploadOptions, callback) {
+									assert.deepEqual(uploadOptions, {});
+									assert.strictEqual(uploadParams.Bucket, 'other-dev-bucket');
+									assert.strictEqual(uploadParams.Key, randomGuid);
+									assert.strictEqual(uploadParams.ContentType, 'text/plain');
+									assert.strictEqual(uploadParams.ContentLength, contentLength);
+									assert(_.isFunction(uploadParams.Body.pipe));
+									const streamContent = await new Promise((resolve, reject) => {
+										let acc = '';
+										uploadParams.Body.on('data', (chunk) => {
+											acc += chunk.toString();
+										});
+										uploadParams.Body.on('end', (chunk) => {
+											if (chunk) {
+												acc += chunk.toString();
+											}
+											resolve(acc);
+										});
+										uploadParams.Body.on('error', reject);
+									});
+									assert.strictEqual(streamContent, 'Example content');
+									callback(null, {
+										Bucket: uploadParams.Bucket,
+										Key: uploadParams.Key,
+									});
+								}
+								getSignedUrl (operation, signedParams, callback) {
+									currentTime = moment();
+									assert.strictEqual(operation, 'getObject');
+									assert.strictEqual(signedParams.Bucket, 'other-dev-bucket');
+									assert.strictEqual(signedParams.Key, randomGuid);
+									assert.strictEqual(signedParams.Expires, 21600);
+									callback(null, 'https://test.aws.com/buckethash');
+								}
+							}
+						}
+					},
+					{
+						dev: true
+					}
+				);
+
+				const uploadResult = await falafel.files.upload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					length: contentLength,
+					file: testFilePath
+				});
+
+				assert.strictEqual(uploadResult.name, 'example.txt');
+				assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+				assert.strictEqual(uploadResult.mime_type, 'text/plain');
+				assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+			} finally {
+				delete process.env.CONNECTOR_FILE_DEV_BUCKET;
+			}
+		});
+
+		it(`should error in correct format if length is not provided`, async () => {
+			const testFilePath = '/tmp/falafel/tests/example.txt';
+			fs.ensureFileSync(testFilePath);
+			fs.writeFileSync(testFilePath, 'Example content');
+			const contentLength = Buffer.byteLength('Example content', 'utf8');
+
+			getProxiedFileHandler({});
+
+			try {
+				const uploadResult = await falafel.files.upload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					file: testFilePath
+				});
+				assert.fail(uploadResult);
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, '`length` must be specified for file uploading.');
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+
+		it(`should surface error in correct format if upload errors`, async () => {
+			const testFilePath = '/tmp/falafel/tests/example.txt';
+			fs.ensureFileSync(testFilePath);
+			fs.writeFileSync(testFilePath, 'Example content');
+			const contentLength = Buffer.byteLength('Example content', 'utf8');
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-2' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.deepEqual(uploadOptions, {});
+							assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+							assert.strictEqual(uploadParams.ContentLength, contentLength);
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(new Error('Some upload error'), null);
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							assert.fail();
+						}
+					}
+				}
+			});
+
+			try {
+				const uploadResult = await falafel.files.upload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					length: contentLength,
+					file: testFilePath
+				});
+				assert.fail(uploadResult);
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, 'An issue has occured when attempting to upload the file.');
+					assert.strictEqual(uploadError.payload.error, 'Some upload error');
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+
+		it(`should surface error in correct format if getSignedUrl errors`, async () => {
+			const testFilePath = '/tmp/falafel/tests/example.txt';
+			fs.ensureFileSync(testFilePath);
+			fs.writeFileSync(testFilePath, 'Example content');
+			const contentLength = Buffer.byteLength('Example content', 'utf8');
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-2' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.deepEqual(uploadOptions, {});
+							assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+							assert.strictEqual(uploadParams.ContentLength, contentLength);
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(null, {
+								Bucket: uploadParams.Bucket,
+								Key: uploadParams.Key,
+							});
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							currentTime = moment();
+							assert.strictEqual(operation, 'getObject');
+							assert.strictEqual(signedParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(signedParams.Key, randomGuid);
+							assert.strictEqual(signedParams.Expires, 21600);
+							callback(new Error('Some getSignedUrl error'), null);
+						}
+					}
+				}
+			});
+
+			try {
+				const uploadResult = await falafel.files.upload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					length: contentLength,
+					file: testFilePath
+				});
+				assert.fail(uploadResult);
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, 'An issue has occured when attempting to upload the file.');
+					assert.strictEqual(uploadError.payload.error, 'Some getSignedUrl error');
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+	});
+
+	describe('streamUpload', () => {
+
+		beforeEach(beforeEachFunc);
+		afterEach(afterEachFunc);
+
+		it(`should upload file from readStream`, async () => {
+			const passThroughStream = new stream.PassThrough();
+			const contentLength = Buffer.byteLength('Example content', 'utf8');
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-2' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+							assert.strictEqual(uploadParams.ContentLength, contentLength);
+
+							assert.deepEqual(
+								uploadOptions,
+								{
+									partSize: 8388608,
+									queueSize: 4,
+								}
+							);
+
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(null, {
+								Bucket: uploadParams.Bucket,
+								Key: uploadParams.Key,
+							});
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							currentTime = moment();
+							assert.strictEqual(operation, 'getObject');
+							assert.strictEqual(signedParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(signedParams.Key, randomGuid);
+							assert.strictEqual(signedParams.Expires, 21600);
+							callback(null, 'https://test.aws.com/buckethash');
+						}
+					}
+				}
+			});
+
+			setTimeout(() => {
+				passThroughStream.write('Example content');
+				passThroughStream.end();
+			}, 500);
+			const uploadResult = await falafel.files.streamUpload({
+				contentType: 'text/plain',
+				name: 'example.txt',
+				length: contentLength,
+				readStream: passThroughStream
+			});
+
+			assert.strictEqual(uploadResult.name, 'example.txt');
+			assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+			assert.strictEqual(uploadResult.mime_type, 'text/plain');
+			assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+		});
+
+		it('should error if readStream is not provided', async () => {
+			getProxiedFileHandler();
+
+			try {
+				await falafel.files.streamUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					length: 123,
+				});
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, `The object passed in must contain the property 'readStream', referecing a read stream.`);
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+
+		it('should error if readStream is not a stream', async () => {
+			getProxiedFileHandler();
+
+			try {
+				await falafel.files.streamUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					length: 123,
+					readStream: {}
+				});
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, `The object passed in must contain the property 'readStream', referecing a read stream.`);
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+
+		it('should error if length is not provided', async () => {
+			const passThroughStream = new stream.PassThrough();
+			passThroughStream.write('test');
+			passThroughStream.end();
+
+			getProxiedFileHandler();
+			try {
+				await falafel.files.streamUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					readStream: passThroughStream
+				});
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, '`length` must be specified for file uploading.');
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+
+	});
+
+	describe('streamMPUpload (and streamUpload)', () => {
+
+		beforeEach(() => {
+			beforeEachFunc();
+		});
+		afterEach(() => {
+			afterEachFunc();
+		});
+
+		it(`should upload file from readStream`, async () => {
+			const passThroughStream = new stream.PassThrough();
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-2' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+
+							assert.deepEqual(
+								uploadOptions,
+								{
+									partSize: 8388608,
+									queueSize: 4,
+								}
+							);
+
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(null, {
+								Bucket: uploadParams.Bucket,
+								Key: uploadParams.Key,
+							});
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							currentTime = moment();
+							assert.strictEqual(operation, 'getObject');
+							assert.strictEqual(signedParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(signedParams.Key, randomGuid);
+							assert.strictEqual(signedParams.Expires, 21600);
+							callback(null, 'https://test.aws.com/buckethash');
+						}
+					}
+				}
+			});
+
+			setTimeout(() => {
+				passThroughStream.write('Example content');
+				passThroughStream.end();
+			}, 500);
+			const uploadResult = await falafel.files.streamMPUpload({
+				contentType: 'text/plain',
+				name: 'example.txt',
+				readStream: passThroughStream
+			});
+
+			assert.strictEqual(uploadResult.name, 'example.txt');
+			assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+			assert.strictEqual(uploadResult.mime_type, 'text/plain');
+			assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+		});
+
+		it(`should upload file to dev bucket in dev mode`, async () => {
+			const passThroughStream = new stream.PassThrough();
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler(
+				{
+					'mout/random/guid': () => {
+						return randomGuid;
+					},
+					'aws-sdk': {
+						'S3': class S3 {
+							constructor (params) {
+								assert.deepEqual(
+									params,
+									{ region: 'us-west-2' }
+								);
+							}
+							async upload (uploadParams, uploadOptions, callback) {
+								assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads-dev');
+								assert.strictEqual(uploadParams.Key, randomGuid);
+								assert.strictEqual(uploadParams.ContentType, 'text/plain');
+
+								assert.deepEqual(
+									uploadOptions,
+									{
+										partSize: 8388608,
+										queueSize: 4,
+									}
+								);
+
+								assert(_.isFunction(uploadParams.Body.pipe));
+								const streamContent = await new Promise((resolve, reject) => {
+									let acc = '';
+									uploadParams.Body.on('data', (chunk) => {
+										acc += chunk.toString();
+									});
+									uploadParams.Body.on('end', (chunk) => {
+										if (chunk) {
+											acc += chunk.toString();
+										}
+										resolve(acc);
+									});
+									uploadParams.Body.on('error', reject);
+								});
+								assert.strictEqual(streamContent, 'Example content');
+								callback(null, {
+									Bucket: uploadParams.Bucket,
+									Key: uploadParams.Key,
+								});
+							}
+							getSignedUrl (operation, signedParams, callback) {
+								currentTime = moment();
+								assert.strictEqual(operation, 'getObject');
+								assert.strictEqual(signedParams.Bucket, 'workflow-file-uploads-dev');
+								assert.strictEqual(signedParams.Key, randomGuid);
+								assert.strictEqual(signedParams.Expires, 21600);
+								callback(null, 'https://test.aws.com/buckethash');
+							}
+						}
+					}
+				},
+				{
+					dev: true
+				}
+			);
+
+			setTimeout(() => {
+				passThroughStream.write('Example content');
+				passThroughStream.end();
+			}, 500);
+			const uploadResult = await falafel.files.streamMPUpload({
+				contentType: 'text/plain',
+				name: 'example.txt',
+				readStream: passThroughStream
+			});
+
+			assert.strictEqual(uploadResult.name, 'example.txt');
+			assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+			assert.strictEqual(uploadResult.mime_type, 'text/plain');
+			assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+		});
+
+		it(`should override default bucket and region if specified`, async () => {
+			const passThroughStream = new stream.PassThrough();
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-1' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.strictEqual(uploadParams.Bucket, 'other-bucket');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+
+							assert.deepEqual(
+								uploadOptions,
+								{
+									partSize: 8388608,
+									queueSize: 4,
+								}
+							);
+
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(null, {
+								Bucket: uploadParams.Bucket,
+								Key: uploadParams.Key,
+							});
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							currentTime = moment();
+							assert.strictEqual(operation, 'getObject');
+							assert.strictEqual(signedParams.Bucket, 'other-bucket');
+							assert.strictEqual(signedParams.Key, randomGuid);
+							assert.strictEqual(signedParams.Expires, 21600);
+							callback(null, 'https://test.aws.com/buckethash');
+						}
+					}
+				}
+			});
+
+			setTimeout(() => {
+				passThroughStream.write('Example content');
+				passThroughStream.end();
+			}, 500);
+			const uploadResult = await falafel.files.streamMPUpload({
+				bucket: 'other-bucket',
+				region: 'us-west-1',
+				contentType: 'text/plain',
+				name: 'example.txt',
+				readStream: passThroughStream
+			});
+
+			assert.strictEqual(uploadResult.name, 'example.txt');
+			assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+			assert.strictEqual(uploadResult.mime_type, 'text/plain');
+			assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+		});
+
+		it(`should override default bucket and region if specified in environment`, async () => {
+			process.env.CONNECTOR_FILE_BUCKET = 'other-bucket';
+			process.env.CONNECTOR_FILE_REGION = 'us-west-1';
+
+			try {
+				const passThroughStream = new stream.PassThrough();
+
+				const randomGuid = guid();
+				let currentTime;
+				getProxiedFileHandler({
+					'mout/random/guid': () => {
+						return randomGuid;
+					},
+					'aws-sdk': {
+						'S3': class S3 {
+							constructor (params) {
+								assert.deepEqual(
+									params,
+									{ region: 'us-west-1' }
+								);
+							}
+							async upload (uploadParams, uploadOptions, callback) {
+								assert.strictEqual(uploadParams.Bucket, 'other-bucket');
+								assert.strictEqual(uploadParams.Key, randomGuid);
+								assert.strictEqual(uploadParams.ContentType, 'text/plain');
+
+								assert.deepEqual(
+									uploadOptions,
+									{
+										partSize: 8388608,
+										queueSize: 4,
+									}
+								);
+
+								assert(_.isFunction(uploadParams.Body.pipe));
+								const streamContent = await new Promise((resolve, reject) => {
+									let acc = '';
+									uploadParams.Body.on('data', (chunk) => {
+										acc += chunk.toString();
+									});
+									uploadParams.Body.on('end', (chunk) => {
+										if (chunk) {
+											acc += chunk.toString();
+										}
+										resolve(acc);
+									});
+									uploadParams.Body.on('error', reject);
+								});
+								assert.strictEqual(streamContent, 'Example content');
+								callback(null, {
+									Bucket: uploadParams.Bucket,
+									Key: uploadParams.Key,
+								});
+							}
+							getSignedUrl (operation, signedParams, callback) {
+								currentTime = moment();
+								assert.strictEqual(operation, 'getObject');
+								assert.strictEqual(signedParams.Bucket, 'other-bucket');
+								assert.strictEqual(signedParams.Key, randomGuid);
+								assert.strictEqual(signedParams.Expires, 21600);
+								callback(null, 'https://test.aws.com/buckethash');
+							}
+						}
+					}
+				});
+
+				setTimeout(() => {
+					passThroughStream.write('Example content');
+					passThroughStream.end();
+				}, 500);
+				const uploadResult = await falafel.files.streamMPUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					readStream: passThroughStream
+				});
+
+				assert.strictEqual(uploadResult.name, 'example.txt');
+				assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+				assert.strictEqual(uploadResult.mime_type, 'text/plain');
+				assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+			} finally {
+				delete process.env.CONNECTOR_FILE_BUCKET;
+				delete process.env.CONNECTOR_FILE_REGION;
+			}
+		});
+
+		it(`should override default dev bucket in dev mode if specified in environment`, async () => {
+			process.env.CONNECTOR_FILE_DEV_BUCKET = 'other-dev-bucket';
+
+			try {
+				const passThroughStream = new stream.PassThrough();
+
+				const randomGuid = guid();
+				let currentTime;
+				getProxiedFileHandler(
+					{
+						'mout/random/guid': () => {
+							return randomGuid;
+						},
+						'aws-sdk': {
+							'S3': class S3 {
+								constructor (params) {
+									assert.deepEqual(
+										params,
+										{ region: 'us-west-2' }
+									);
+								}
+								async upload (uploadParams, uploadOptions, callback) {
+									assert.strictEqual(uploadParams.Bucket, 'other-dev-bucket');
+									assert.strictEqual(uploadParams.Key, randomGuid);
+									assert.strictEqual(uploadParams.ContentType, 'text/plain');
+
+									assert.deepEqual(
+										uploadOptions,
+										{
+											partSize: 8388608,
+											queueSize: 4,
+										}
+									);
+
+									assert(_.isFunction(uploadParams.Body.pipe));
+									const streamContent = await new Promise((resolve, reject) => {
+										let acc = '';
+										uploadParams.Body.on('data', (chunk) => {
+											acc += chunk.toString();
+										});
+										uploadParams.Body.on('end', (chunk) => {
+											if (chunk) {
+												acc += chunk.toString();
+											}
+											resolve(acc);
+										});
+										uploadParams.Body.on('error', reject);
+									});
+									assert.strictEqual(streamContent, 'Example content');
+									callback(null, {
+										Bucket: uploadParams.Bucket,
+										Key: uploadParams.Key,
+									});
+								}
+								getSignedUrl (operation, signedParams, callback) {
+									currentTime = moment();
+									assert.strictEqual(operation, 'getObject');
+									assert.strictEqual(signedParams.Bucket, 'other-dev-bucket');
+									assert.strictEqual(signedParams.Key, randomGuid);
+									assert.strictEqual(signedParams.Expires, 21600);
+									callback(null, 'https://test.aws.com/buckethash');
+								}
+							}
+						}
+					},
+					{
+						dev: true
+					}
+				);
+
+				setTimeout(() => {
+					passThroughStream.write('Example content');
+					passThroughStream.end();
+				}, 500);
+				const uploadResult = await falafel.files.streamMPUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					readStream: passThroughStream
+				});
+
+				assert.strictEqual(uploadResult.name, 'example.txt');
+				assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+				assert.strictEqual(uploadResult.mime_type, 'text/plain');
+				assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+			} finally {
+				delete process.env.CONNECTOR_FILE_DEV_BUCKET;
+			}
+		});
+
+		it(`should increase queueSize if CONNECTOR_MAX_ALLOCATED_RAM_MB is defined`, async () => {
+			process.env.CONNECTOR_MAX_ALLOCATED_RAM_MB = 512;
+
+			try {
+				const passThroughStream = new stream.PassThrough();
+
+				const randomGuid = guid();
+				let currentTime;
+				getProxiedFileHandler({
+					'mout/random/guid': () => {
+						return randomGuid;
+					},
+					'aws-sdk': {
+						'S3': class S3 {
+							constructor (params) {
+								assert.deepEqual(
+									params,
+									{ region: 'us-west-2' }
+								);
+							}
+							async upload (uploadParams, uploadOptions, callback) {
+								assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads');
+								assert.strictEqual(uploadParams.Key, randomGuid);
+								assert.strictEqual(uploadParams.ContentType, 'text/plain');
+
+								assert.deepEqual(
+									uploadOptions,
+									{
+										partSize: 33554432,
+										queueSize: 12,
+									}
+								);
+
+								assert(_.isFunction(uploadParams.Body.pipe));
+								const streamContent = await new Promise((resolve, reject) => {
+									let acc = '';
+									uploadParams.Body.on('data', (chunk) => {
+										acc += chunk.toString();
+									});
+									uploadParams.Body.on('end', (chunk) => {
+										if (chunk) {
+											acc += chunk.toString();
+										}
+										resolve(acc);
+									});
+									uploadParams.Body.on('error', reject);
+								});
+								assert.strictEqual(streamContent, 'Example content');
+								callback(null, {
+									Bucket: uploadParams.Bucket,
+									Key: uploadParams.Key,
+								});
+							}
+							getSignedUrl (operation, signedParams, callback) {
+								currentTime = moment();
+								assert.strictEqual(operation, 'getObject');
+								assert.strictEqual(signedParams.Bucket, 'workflow-file-uploads');
+								assert.strictEqual(signedParams.Key, randomGuid);
+								assert.strictEqual(signedParams.Expires, 21600);
+								callback(null, 'https://test.aws.com/buckethash');
+							}
+						}
+					}
+				});
+
+				setTimeout(() => {
+					passThroughStream.write('Example content');
+					passThroughStream.end();
+				}, 500);
+				const uploadResult = await falafel.files.streamMPUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					readStream: passThroughStream
+				});
+
+				assert.strictEqual(uploadResult.name, 'example.txt');
+				assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+				assert.strictEqual(uploadResult.mime_type, 'text/plain');
+				assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+			} finally {
+				delete process.env.CONNECTOR_MAX_ALLOCATED_RAM_MB;
+			}
+		});
+
+		it(`should increase queueSize if fileSize is greater than half the available RAM`, async () => {
+			const passThroughStream = new stream.PassThrough();
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-2' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+
+							assert.deepEqual(
+								uploadOptions,
+								{
+									partSize: 8388608,
+									queueSize: 12,
+								}
+							);
+
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(null, {
+								Bucket: uploadParams.Bucket,
+								Key: uploadParams.Key,
+							});
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							currentTime = moment();
+							assert.strictEqual(operation, 'getObject');
+							assert.strictEqual(signedParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(signedParams.Key, randomGuid);
+							assert.strictEqual(signedParams.Expires, 21600);
+							callback(null, 'https://test.aws.com/buckethash');
+						}
+					}
+				}
+			});
+
+			setTimeout(() => {
+				passThroughStream.write('Example content');
+				passThroughStream.end();
+			}, 500);
+			const uploadResult = await falafel.files.streamMPUpload({
+				contentType: 'text/plain',
+				name: 'example.txt',
+				readStream: passThroughStream,
+				length: 68000000
+			});
+
+			assert.strictEqual(uploadResult.name, 'example.txt');
+			assert.strictEqual(uploadResult.url, 'https://test.aws.com/buckethash');
+			assert.strictEqual(uploadResult.mime_type, 'text/plain');
+			assert.strictEqual(uploadResult.expires, currentTime.add(6, 'hours').unix());
+		});
+
+		it('should error if readStream is not provided', async () => {
+			getProxiedFileHandler();
+
+			try {
+				await falafel.files.streamMPUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+				});
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, `The object passed in must contain the property 'readStream', referecing a read stream.`);
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+
+		it('should error if readStream is not a stream', async () => {
+			getProxiedFileHandler();
+
+			try {
+				await falafel.files.streamMPUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					readStream: {}
+				});
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, `The object passed in must contain the property 'readStream', referecing a read stream.`);
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+
+		it(`should surface error in correct format if upload errors`, async () => {
+			const passThroughStream = new stream.PassThrough();
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-2' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+
+							assert.deepEqual(
+								uploadOptions,
+								{
+									partSize: 8388608,
+									queueSize: 4,
+								}
+							);
+
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(new Error('Some upload error'), null);
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							assert.fail();
+						}
+					}
+				}
+			});
+
+			try {
+				setTimeout(() => {
+					passThroughStream.write('Example content');
+					passThroughStream.end();
+				}, 500);
+				const uploadResult = await falafel.files.streamMPUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					readStream: passThroughStream
+				});
+				assert.fail(uploadResult);
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, 'An issue has occured when attempting to upload the file.');
+					assert.strictEqual(uploadError.payload.error, 'Some upload error');
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+
+		it(`should surface error in correct format if getSignedUrl errors`, async () => {
+			const passThroughStream = new stream.PassThrough();
+
+			const randomGuid = guid();
+			let currentTime;
+			getProxiedFileHandler({
+				'mout/random/guid': () => {
+					return randomGuid;
+				},
+				'aws-sdk': {
+					'S3': class S3 {
+						constructor (params) {
+							assert.deepEqual(
+								params,
+								{ region: 'us-west-2' }
+							);
+						}
+						async upload (uploadParams, uploadOptions, callback) {
+							assert.strictEqual(uploadParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(uploadParams.Key, randomGuid);
+							assert.strictEqual(uploadParams.ContentType, 'text/plain');
+
+							assert.deepEqual(
+								uploadOptions,
+								{
+									partSize: 8388608,
+									queueSize: 4,
+								}
+							);
+
+							assert(_.isFunction(uploadParams.Body.pipe));
+							const streamContent = await new Promise((resolve, reject) => {
+								let acc = '';
+								uploadParams.Body.on('data', (chunk) => {
+									acc += chunk.toString();
+								});
+								uploadParams.Body.on('end', (chunk) => {
+									if (chunk) {
+										acc += chunk.toString();
+									}
+									resolve(acc);
+								});
+								uploadParams.Body.on('error', reject);
+							});
+							assert.strictEqual(streamContent, 'Example content');
+							callback(null, {
+								Bucket: uploadParams.Bucket,
+								Key: uploadParams.Key,
+							});
+						}
+						getSignedUrl (operation, signedParams, callback) {
+							currentTime = moment();
+							assert.strictEqual(operation, 'getObject');
+							assert.strictEqual(signedParams.Bucket, 'workflow-file-uploads');
+							assert.strictEqual(signedParams.Key, randomGuid);
+							assert.strictEqual(signedParams.Expires, 21600);
+							callback(new Error('Some getSignedUrl error'), null);
+						}
+					}
+				}
+			});
+
+			try {
+				setTimeout(() => {
+					passThroughStream.write('Example content');
+					passThroughStream.end();
+				}, 500);
+				const uploadResult = await falafel.files.streamMPUpload({
+					contentType: 'text/plain',
+					name: 'example.txt',
+					readStream: passThroughStream
+				});
+				assert.fail(uploadResult);
+			} catch (uploadError) {
+				try {
+					assert.strictEqual(uploadError.code, '#connector_error');
+					assert.strictEqual(uploadError.message, 'An issue has occured when attempting to upload the file.');
+					assert.strictEqual(uploadError.payload.error, 'Some getSignedUrl error');
+				} catch (otherError) {
+					assert.fail(uploadError);
+				}
+			}
+		});
+	});
+
+	const random2xx = _.random(200, 299),
+		random4xx = _.random(400, 499),
+		randomNon2xx = ( _.random(0, 1) ? _.random(0, 199) : _.random(300, 599));
+
+	describe('download', () => {
+		beforeEach(beforeEachFunc);
+		afterEach(afterEachFunc);
+
+		it(`should download a file from a URL for statusCode between 200 and 300 - (${random2xx})`, async () => {
+			const baseUrl = 'https://example.aws.com',
+				endpoint = '/somefile';
+
+			nock(baseUrl)
+			.get(endpoint)
+			.reply(
+				200,
+				(uri, reqBody) => {
+					return 'Example content';
+				}
+			);
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.strictEqual(url, `${baseUrl}${endpoint}`);
+						assert.strictEqual(options.decode_response, false);
+						assert.strictEqual(options.parse, false);
+						assert.strictEqual(options.open_timeout, 0);
+						assert.strictEqual(options.read_timeout, 0);
+						assert.strictEqual(options.output, '/tmp/somefile.txt');
+						return needle.get(url, options, callback);
+					}
+				}
+			});
+
+			const downloadResult = await falafel.files.download({
+				url: `${baseUrl}${endpoint}`,
+				name: 'somefile.txt',
+				mime_type: 'text/plain',
+				expires: 1591484751
+			});
+
+			assert.strictEqual(downloadResult.file, '/tmp/somefile.txt');
+			assert.strictEqual(downloadResult.name, 'somefile.txt');
+			assert.strictEqual(downloadResult.mime_type, 'text/plain');
+			assert.strictEqual(downloadResult.expires, 1591484751);
+			assert.strictEqual(fs.readFileSync(downloadResult.file, 'utf8'), 'Example content');
+		});
+
+		it(`should reject with expiry error for statusCode between 400 and 500 if from s3 for v2 signature - (${random4xx})`, async () => {
+			const baseUrl = 'https://example.amazonaws.com',
+				endpoint = '/somefile',
+				queryParams = { 'Expires': '1593320298' };
+			const queryString = (new URLSearchParams(queryParams)).toString();
+			const fullUrl = `${baseUrl}${endpoint}?${queryString}`;
+
+			nock(baseUrl)
+			.get(endpoint)
+			.query(queryParams)
+			.reply(
+				random4xx,
+				(uri, reqBody) => {
+					return 'Request has expired';
+				},
+				{
+					'content-type': 'application/xml',
+					server: 'AmazonS3'
+				}
+			);
+
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.strictEqual(url, fullUrl);
+						assert.strictEqual(options.decode_response, false);
+						assert.strictEqual(options.parse, false);
+						assert.strictEqual(options.open_timeout, 0);
+						assert.strictEqual(options.read_timeout, 0);
+						assert(_.isString(options.output));
+						return needle.get(url, options, callback);
+					}
+				}
+			});
+
+			try {
+				await falafel.files.download({
+					url: fullUrl,
+					name: 'somefile.txt',
+					mime_type: 'text/plain',
+					expires: 1593320298
+				});
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.message, 'The file provided has expired. Please note that links to files downloaded by connectors expire within 6 hours.');
+				assert.strictEqual(downloadError.payload.datetime_expired, moment(queryParams['Expires'], 'X').format());
+			}
+		});
+
+		it(`should reject with expiry error for statusCode between 400 and 500 if from s3 for v4 signature - (${random4xx})`, async () => {
+			const baseUrl = 'https://example.amazonaws.com',
+				endpoint = '/somefile',
+				queryParams = {
+					'X-Amz-Date': '20200628T160000Z',
+					'X-Amz-Expires': 86400
+				};
+			const queryString = (new URLSearchParams(queryParams)).toString();
+			const fullUrl = `${baseUrl}${endpoint}?${queryString}`;
+
+			nock(baseUrl)
+			.get(endpoint)
+			.query(queryParams)
+			.reply(
+				random4xx,
+				(uri, reqBody) => {
+					return 'Request has expired';
+				},
+				{
+					'content-type': 'application/xml',
+					server: 'AmazonS3'
+				}
+			);
+
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.strictEqual(url, fullUrl);
+						assert.strictEqual(options.decode_response, false);
+						assert.strictEqual(options.parse, false);
+						assert.strictEqual(options.open_timeout, 0);
+						assert.strictEqual(options.read_timeout, 0);
+						assert(_.isString(options.output));
+						return needle.get(url, options, callback);
+					}
+				}
+			});
+
+			try {
+				await falafel.files.download({
+					url: fullUrl,
+					name: 'somefile.txt',
+					mime_type: 'text/plain',
+					expires: 1593442800
+				});
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.message, 'The file provided has expired. Please note that links to files downloaded by connectors expire within 6 hours.');
+				assert.strictEqual(downloadError.payload.datetime_expired, moment(queryParams['X-Amz-Date'], 'YYYYMMDD[T]HHmmss[Z]').add(queryParams['X-Amz-Expires'], 's').format());
+			}
+		});
+
+		it(`should reject with standard status code error message for any other unexpected response - (${randomNon2xx})`, async () => {
+			const baseUrl = 'https://example.aws.com',
+				endpoint = '/somefile';
+
+			nock(baseUrl)
+			.get(endpoint)
+			.reply(
+				randomNon2xx,
+				(uri, reqBody) => {
+					return 'Some error';
+				}
+			);
+
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.strictEqual(url, `${baseUrl}${endpoint}`);
+						assert.strictEqual(options.decode_response, false);
+						assert.strictEqual(options.parse, false);
+						assert.strictEqual(options.open_timeout, 0);
+						assert.strictEqual(options.read_timeout, 0);
+						assert(_.isString(options.output));
+						return needle.get(url, options, callback);
+					}
+				}
+			});
+
+			try {
+				await falafel.files.download({
+					url: `${baseUrl}${endpoint}`,
+					name: 'somefile.txt',
+					mime_type: 'text/plain',
+					expires: 1591484751
+				});
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.message, 'An issue has occured when attempting to download the file.');
+				assert.strictEqual(downloadError.payload.error, `Status code: ${randomNon2xx}`);
+			}
+
+		});
+	});
+
+	describe('streamDownload', () => {
+		beforeEach(beforeEachFunc);
+		afterEach(afterEachFunc);
+
+		it(`should return a stream for URL for statusCode between 200 and 300 - (${random2xx})`, async () => {
+			const baseUrl = 'https://example.aws.com',
+				endpoint = '/somefile';
+
+			nock(baseUrl)
+			.get(endpoint)
+			.reply(
+				random2xx,
+				(uri, reqBody) => {
+					return 'Example content';
+				},
+				{
+					'content-length': Buffer.byteLength('Example content', 'utf8')
+				}
+			);
+
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.strictEqual(url, `${baseUrl}${endpoint}`);
+						assert.strictEqual(options.decode_response, false);
+						assert.strictEqual(options.parse, false);
+						assert.strictEqual(options.open_timeout, 0);
+						assert.strictEqual(options.read_timeout, 0);
+						return needle.get(url, options, callback);
+					}
+				}
+			});
+
+			const downloadObject = await falafel.files.streamDownload({
+				url: `${baseUrl}${endpoint}`,
+				name: 'somefile.txt',
+				mime_type: 'text/plain',
+				expires: 1591484751
+			});
+
+
+			assert(_.isPlainObject(downloadObject));
+			assert.strictEqual(downloadObject.name, 'somefile.txt');
+			assert.strictEqual(downloadObject.mime_type, 'text/plain');
+			assert.strictEqual(downloadObject.expires, 1591484751);
+			assert.equal(downloadObject.size, 15);
+
+			const downloadStream = downloadObject.readStream;
+			assert(_.isFunction(downloadStream.pipe));
+			assert(_.isFunction(downloadStream.on));
+
+			await new Promise((resolve, reject) => {
+				let acc = '';
+				downloadStream.on('data', (chunk) => {
+					acc += chunk.toString();
+				});
+
+				downloadStream.on('end', () => {
+					try {
+						assert.strictEqual(acc, 'Example content');
+						resolve();
+					} catch (asertError) {
+						reject(asertError);
+					}
+				});
+
+				downloadStream.on('error', reject);
+			});
+		});
+
+		it(`should reject with expiry error for statusCode between 400 and 500 if from s3 for v2 signature - (${random4xx})`, async () => {
+			const baseUrl = 'https://example.amazonaws.com',
+				endpoint = '/somefile',
+				queryParams = { 'Expires': '1593320298' };
+			const queryString = (new URLSearchParams(queryParams)).toString();
+			const fullUrl = `${baseUrl}${endpoint}?${queryString}`;
+
+			nock(baseUrl)
+			.get(endpoint)
+			.query(queryParams)
+			.reply(
+				random4xx,
+				(uri, reqBody) => {
+					return 'Request has expired';
+				},
+				{
+					'content-type': 'application/xml',
+					server: 'AmazonS3'
+				}
+			);
+
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.strictEqual(url, fullUrl);
+						assert.strictEqual(options.decode_response, false);
+						assert.strictEqual(options.parse, false);
+						assert.strictEqual(options.open_timeout, 0);
+						assert.strictEqual(options.read_timeout, 0);
+						return needle.get(url, options, callback);
+					}
+				}
+			});
+
+			try {
+				await falafel.files.streamDownload({
+					url: fullUrl,
+					name: 'somefile.txt',
+					mime_type: 'text/plain',
+					expires: 1593320298
+				});
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.message, 'The file provided has expired. Please note that links to files downloaded by connectors expire within 6 hours.');
+				assert.strictEqual(downloadError.payload.datetime_expired, moment(queryParams['Expires'], 'X').format());
+			}
+
+		});
+
+		it(`should reject with expiry error for statusCode between 400 and 500 if from s3 for v4 signature - (${random4xx})`, async () => {
+			const baseUrl = 'https://example.amazonaws.com',
+				endpoint = '/somefile',
+				queryParams = {
+					'X-Amz-Date': '20200628T160000Z',
+					'X-Amz-Expires': 86400
+				};
+			const queryString = (new URLSearchParams(queryParams)).toString();
+			const fullUrl = `${baseUrl}${endpoint}?${queryString}`;
+
+			nock(baseUrl)
+			.get(endpoint)
+			.query(queryParams)
+			.reply(
+				random4xx,
+				(uri, reqBody) => {
+					return 'Request has expired';
+				},
+				{
+					'content-type': 'application/xml',
+					server: 'AmazonS3'
+				}
+			);
+
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.strictEqual(url, fullUrl);
+						assert.strictEqual(options.decode_response, false);
+						assert.strictEqual(options.parse, false);
+						assert.strictEqual(options.open_timeout, 0);
+						assert.strictEqual(options.read_timeout, 0);
+						return needle.get(url, options, callback);
+					}
+				}
+			});
+
+			try {
+				await falafel.files.streamDownload({
+					url: fullUrl,
+					name: 'somefile.txt',
+					mime_type: 'text/plain',
+					expires: 1593442800
+				});
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.message, 'The file provided has expired. Please note that links to files downloaded by connectors expire within 6 hours.');
+				assert.strictEqual(downloadError.payload.datetime_expired, moment(queryParams['X-Amz-Date'], 'YYYYMMDD[T]HHmmss[Z]').add(queryParams['X-Amz-Expires'], 's').format());
+			}
+
+		});
+
+		it(`should reject with standard status code error message for any other unexpected response - (${randomNon2xx})`, async () => {
+			const baseUrl = 'https://example.aws.com',
+				endpoint = '/somefile';
+
+			nock(baseUrl)
+			.get(endpoint)
+			.reply(
+				randomNon2xx,
+				(uri, reqBody) => {
+					return 'Some error';
+				}
+			);
+
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.strictEqual(url, `${baseUrl}${endpoint}`);
+						assert.strictEqual(options.decode_response, false);
+						assert.strictEqual(options.parse, false);
+						assert.strictEqual(options.open_timeout, 0);
+						assert.strictEqual(options.read_timeout, 0);
+						return needle.get(url, options, callback);
+					}
+				}
+			});
+
+			try {
+				await falafel.files.download({
+					url: `${baseUrl}${endpoint}`,
+					name: 'somefile.txt',
+					mime_type: 'text/plain',
+					expires: 1591484751
+				});
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.message, 'An issue has occured when attempting to download the file.');
+				assert.strictEqual(downloadError.payload.error, `Status code: ${randomNon2xx}`);
+			}
+
+		});
+	});
+});

--- a/test/fileHandler/index_test.js
+++ b/test/fileHandler/index_test.js
@@ -1736,8 +1736,55 @@ describe('#fileHandler', function () {
 				assert.strictEqual(downloadError.message, 'An issue has occured when attempting to download the file.');
 				assert.strictEqual(downloadError.payload.error, `Status code: ${randomNon2xx}`);
 			}
-
 		});
+        
+		it('should throw error if invalid file object passed through', async () => {
+			const invalidFileObj = {
+				name: 'some.pdf',
+				mime_type: 'application/pdf',
+				expires: 1594289612,
+			};
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.fail(url);
+					}
+				} 
+			});
+
+			try {
+				await falafel.files.download(invalidFileObj);
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.code, '#connector_error');
+				assert.strictEqual(downloadError.message, `The 'url' property is missing. The file object passed through must contain all properties 'name', 'url', 'mime_type', 'expires'.`);
+			}
+		});
+
+		it('should throw error if file object values are of an invalid type', async () => {
+			const invalidFileObj = {
+				name: 'some.pdf',
+				url: 123,
+				mime_type: 'application/pdf',
+				expires: 1594289612,
+			};
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.fail(url);
+					}
+				} 
+			});
+
+			try {
+				await falafel.files.download(invalidFileObj);
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.code, '#connector_error');
+				assert.strictEqual(downloadError.message, `The file object passed through contains invalid type for the 'url' key.`);
+			}
+		});
+
 	});
 
 	describe('streamDownload', () => {
@@ -1951,6 +1998,53 @@ describe('#fileHandler', function () {
 				assert.strictEqual(downloadError.payload.error, `Status code: ${randomNon2xx}`);
 			}
 
+		});
+        
+		it('should throw error if invalid file object passed through', async () => {
+			const invalidFileObj = {
+				name: 'some.pdf',
+				mime_type: 'application/pdf',
+				expires: 1594289612,
+			};
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.fail(url);
+					}
+				} 
+			});
+
+			try {
+				await falafel.files.download(invalidFileObj);
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.code, '#connector_error');
+				assert.strictEqual(downloadError.message, `The 'url' property is missing. The file object passed through must contain all properties 'name', 'url', 'mime_type', 'expires'.`);
+			}
+		});
+
+		it('should throw error if file object values are of an invalid type', async () => {
+			const invalidFileObj = {
+				name: 'some.pdf',
+				url: 123,
+				mime_type: 'application/pdf',
+				expires: 1594289612,
+			};
+
+			getProxiedFileHandler({
+				needle: {
+					get: (url, options, callback) => {
+						assert.fail(url);
+					}
+				} 
+			});
+
+			try {
+				await falafel.files.download(invalidFileObj);
+			} catch (downloadError) {
+				assert.strictEqual(downloadError.code, '#connector_error');
+				assert.strictEqual(downloadError.message, `The file object passed through contains invalid type for the 'url' key.`);
+			}
 		});
 	});
 });

--- a/test/parseConfig/getFunctionParameter.js
+++ b/test/parseConfig/getFunctionParameter.js
@@ -26,7 +26,7 @@ describe('#getFunctionParameter', function () {
 
 
 	it('should return an error if an invalid function string is supplied when the function is evaluated', function () {
-		var fn = getFunctionParameter({ value: 'function { cba' }, 'before');
+		var fn = getFunctionParameter({ value: 'function { cba' }, 'before', 'test_op');
 
 		assert(_.isFunction(fn));
 
@@ -36,17 +36,17 @@ describe('#getFunctionParameter', function () {
 			fn({ sample: 'input' });
 		} catch (err) {
 			assert(_.isError(err));
-			assert.strictEqual(err.message, 'Error evaluating operation "before": Unexpected token {');	
+			assert.strictEqual(err.message, `Error occured for module 'test_op'. Error evaluating function 'before': Unexpected token {`);
 			didCatch = true;
 		}
 
 		assert(didCatch);
-		
+
 	});
 
 
 	it('should return an error if a variable is specified, but it\'s not a function', function () {
-		var fn = getFunctionParameter({ value: '5;' }, 'before');
+		var fn = getFunctionParameter({ value: '5;' }, 'before', 'test_op');
 
 		assert(_.isFunction(fn));
 
@@ -56,12 +56,12 @@ describe('#getFunctionParameter', function () {
 			fn({ sample: 'input' });
 		} catch (err) {
 			assert(_.isError(err));
-			assert.strictEqual(err.message, 'Error evaluating operation "before": Should be a function');
+			assert.strictEqual(err.message, `Error occured for module 'test_op'. Error evaluating function 'before': Should be a function`);
 			didCatch = true;
 		}
 
 		assert(didCatch);
-		
+
 	});
 
 

--- a/test/parseConfig/getGlobalModel.js
+++ b/test/parseConfig/getGlobalModel.js
@@ -9,104 +9,108 @@ describe('#getGlobalModel', function () {
 
 	beforeEach(function () {
 		sampleGlobalModel = {
-		    "type": "object",
-		    "value": {
-		      "afterFailure": {
-		        "type": "function",
-		        "value": "function () { }"
-		      },
-		      "afterSuccess": {
-		        "type": "function",
-		        "value": "function () { }"
-		      },
-		      "auth": {
-		        "type": "object",
-		        "value": {}
-		      },
-		      "baseUrl": {
-		        "type": "string",
-		        "value": "https://app.asana.com/api/1.0"
-		      },
-		      "before": {
-		        "type": "function",
-		        "value": "function () { }"
-		      },
-		      "data": {
-		        "type": "object",
-		        "value": {
-		        	"name": {
-		        		"type": "string",
-		        		"value": "Chris"
-		        	}
-		        }
-		      },
-		      "expects": {
-		        "type": "string",
-		        "value": "2xx"
-		      },
-		      "headers": {
-		        "type": "array",
-		        "value": [{
-		        	"type": "object",
-		        	"value": {
-		        		"name": {
-		        			"type": "string",
-		        			"value": "Content-Type"
-		        		},
-		        		"value": {
-		        			"type": "string",
-		        			"value": "application/json"
-		        		}
-		        	}
-		        }, 
-		        {
-		        	"type": "object",
-		        	"value": {
-		        		"name": {
-		        			"type": "string",
-		        			"value": "Content-Length"
-		        		},
-		        		"value": {
-		        			"type": "number",
-		        			"value": 252
-		        		}
-		        	}
-		        }]
-		      },
-		      "notExpects": {
-		        "type": "function",
-		        "value": "function (input) {}"
-		      },
-		      "query": {
-		        "type": "array",
-		        "value": [{
-		        	"type": "object",
-		        	"value": {
-		        		"key": {
-		        			"type": "string",
-		        			"value": "per_page"
-		        		},
-		        		"value": {
-		        			"type": "string",
-		        			"value": "100"
-		        		}
-		        	}
-		        }, 
-		        {
-		        	"type": "object",
-		        	"value": {
-		        		"key": {
-		        			"type": "string",
-		        			"value": "page"
-		        		},
-		        		"value": {
-		        			"type": "string",
-		        			"value": "1"
-		        		}
-		        	}
-		        }]
-		      }
-		    }
+			'type': 'object',
+			'value': {
+				'afterFailure': {
+					'type': 'function',
+					'value': 'function () { }'
+				},
+				'afterSuccess': {
+					'type': 'function',
+					'value': 'function () { }'
+				},
+				'auth': {
+					'type': 'object',
+					'value': {}
+				},
+				'baseUrl': {
+					'type': 'string',
+					'value': 'https://app.asana.com/api/1.0'
+				},
+				'before': {
+					'type': 'function',
+					'value': 'function () { }'
+				},
+				'data': {
+					'type': 'object',
+					'value': {
+						'name': {
+							'type': 'string',
+							'value': 'Chris'
+						}
+					}
+				},
+				'expects': {
+					'type': 'string',
+					'value': '2xx'
+				},
+				'headers': {
+					'type': 'array',
+					'value': [
+						{
+							'type': 'object',
+							'value': {
+								'name': {
+									'type': 'string',
+									'value': 'Content-Type'
+								},
+								'value': {
+									'type': 'string',
+									'value': 'application/json'
+								}
+							}
+						},
+						{
+							'type': 'object',
+							'value': {
+								'name': {
+									'type': 'string',
+									'value': 'Content-Length'
+								},
+								'value': {
+									'type': 'number',
+									'value': 252
+								}
+							}
+						}
+					]
+				},
+				'notExpects': {
+					'type': 'function',
+					'value': 'function (input) {}'
+				},
+				'query': {
+					'type': 'array',
+					'value': [
+						{
+							'type': 'object',
+							'value': {
+								'key': {
+									'type': 'string',
+									'value': 'per_page'
+								},
+								'value': {
+									'type': 'string',
+									'value': '100'
+								}
+							}
+						},
+						{
+							'type': 'object',
+							'value': {
+								'key': {
+									'type': 'string',
+									'value': 'page'
+								},
+								'value': {
+									'type': 'string',
+									'value': '1'
+								}
+							}
+						}
+					]
+				}
+			}
 		};
 
 		// console.log(sampleGlobalModel)
@@ -114,16 +118,16 @@ describe('#getGlobalModel', function () {
 
 
 	it('should bind base URL', function () {
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
+		const globalModel = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 
 		assert.strictEqual(globalModel.baseUrl, 'https://app.asana.com/api/1.0');
 
 		sampleGlobalModel.value.baseUrl = {
 			type: 'function',
 			value: 'function (input) { return \'https://app.asana.com/api/1.0\'; }',
-		}
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
-		assert(_.isFunction(globalModel.baseUrl));
+		};
+		const globalModel2 = getGlobalModel({ name: 'global_model2', model: sampleGlobalModel });
+		assert(_.isFunction(globalModel2.baseUrl));
 	});
 
 
@@ -135,7 +139,7 @@ describe('#getGlobalModel', function () {
 
 
 	it('should bind the lifecycle methods', function () {
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
+		var globalModel = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 
 		assert(_.isFunction(globalModel.before));
 		assert(_.isFunction(globalModel.afterSuccess));
@@ -144,40 +148,42 @@ describe('#getGlobalModel', function () {
 
 
 	it('should bind the query', function () {
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
-		assert.deepEqual(globalModel.query, { 
-			per_page: '100', 
-			page: '1' 
+		var globalModel = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
+		assert.deepEqual(globalModel.query, {
+			per_page: '100',
+			page: '1'
 		});
 	});
 
 	it('should not bind auth headers with no name', function () {
 		sampleGlobalModel.value.query = {
 			type: 'array',
-			value: [{
-				type: 'object',
-				value: {
-					name: {
-						type: 'string',
-						value: ' '
-					},
+			value: [
+				{
+					type: 'object',
 					value: {
-						type: 'string',
-						value: '123abc'
+						name: {
+							type: 'string',
+							value: ' '
+						},
+						value: {
+							type: 'string',
+							value: '123abc'
+						}
 					}
 				}
-			}]
+			]
 		};
 
-		var model = getGlobalModel({ model: sampleGlobalModel });
+		var model = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 		assert.strictEqual(model.query[' '], undefined);
 	});
 
 
 	it('should bind the headers', function () {
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
-		assert.deepEqual(globalModel.options.headers, { 
-			'Content-Type': 'application/json', 
+		var globalModel = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
+		assert.deepEqual(globalModel.options.headers, {
+			'Content-Type': 'application/json',
 			'Content-Length': 252
 		});
 	});
@@ -185,29 +191,31 @@ describe('#getGlobalModel', function () {
 	it('should not bind auth headers with no name', function () {
 		sampleGlobalModel.value.headers = {
 			type: 'array',
-			value: [{
-				type: 'object',
-				value: {
-					name: {
-						type: 'string',
-						value: ' '
-					},
+			value: [
+				{
+					type: 'object',
 					value: {
-						type: 'string',
-						value: '123abc'
+						name: {
+							type: 'string',
+							value: ' '
+						},
+						value: {
+							type: 'string',
+							value: '123abc'
+						}
 					}
 				}
-			}]
+			]
 		};
 
-		var model = getGlobalModel({ model: sampleGlobalModel });
+		var model = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 		assert.strictEqual(model.options.headers[' '], undefined);
 	});
 
 
 	it('should bind the data', function () {
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
-		assert.deepEqual(globalModel.data, { 
+		var globalModel = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
+		assert.deepEqual(globalModel.data, {
 			name: 'Chris'
 		});
 	});
@@ -220,24 +228,26 @@ describe('#getGlobalModel', function () {
 				value: 'oauth2'
 			},
 			headers: {
-				"type": "array",
-		        "value": [{
-		        	"type": "object",
-		        	"value": {
-		        		"name": {
-		        			"type": "string",
-		        			"value": "Authorization"
-		        		},
-		        		"value": {
-		        			"type": "string",
-		        			"value": "Bearer {{{access_token}}}"
-		        		}
-		        	}
-		        }]
+				'type': 'array',
+				'value': [
+					{
+						'type': 'object',
+						'value': {
+							'name': {
+								'type': 'string',
+								'value': 'Authorization'
+							},
+							'value': {
+								'type': 'string',
+								'value': 'Bearer {{{access_token}}}'
+							}
+						}
+					}
+				]
 			}
 		};
 
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
+		var globalModel = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 		assert.deepEqual(globalModel.options.headers.Authorization, 'Bearer {{{access_token}}}');
 
 
@@ -261,7 +271,7 @@ describe('#getGlobalModel', function () {
 			}
 		};
 
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
+		var globalModel = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 
 		assert.deepEqual(globalModel.options.username, 'admin');
 		assert.deepEqual(globalModel.options.password, 'supersecure');
@@ -276,23 +286,25 @@ describe('#getGlobalModel', function () {
 			},
 			query: {
 				type: 'array',
-				value: [{
-		        	"type": "object",
-		        	"value": {
-		        		"key": {
-		        			"type": "string",
-		        			"value": "api_key"
-		        		},
-		        		"value": {
-		        			"type": "string",
-		        			"value": "123abc"
-		        		}
-		        	}
-		        }]
-		    }
+				value: [
+					{
+						'type': 'object',
+						'value': {
+							'key': {
+								'type': 'string',
+								'value': 'api_key'
+							},
+							'value': {
+								'type': 'string',
+								'value': '123abc'
+							}
+						}
+					}
+				]
+			}
 		};
 
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
+		var globalModel = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 
 		assert.deepEqual(globalModel.query.api_key, '123abc');
 	});
@@ -305,23 +317,25 @@ describe('#getGlobalModel', function () {
 			},
 			query: {
 				type: 'array',
-				value: [{
-					type: 'object',
-					value: {
-						key: {
-							type: 'string',
-							value: ' '
-						},
+				value: [
+					{
+						type: 'object',
 						value: {
-							type: 'string',
-							value: '123abc'
+							key: {
+								type: 'string',
+								value: ' '
+							},
+							value: {
+								type: 'string',
+								value: '123abc'
+							}
 						}
 					}
-				}]
+				]
 			}
 		};
 
-		var model = getGlobalModel({ model: sampleGlobalModel });
+		var model = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 		assert.strictEqual(model.query[' '], undefined);
 	});
 
@@ -334,23 +348,25 @@ describe('#getGlobalModel', function () {
 			},
 			headers: {
 				type: 'array',
-				value: [{
-		        	"type": "object",
-		        	"value": {
-		        		"name": {
-		        			"type": "string",
-		        			"value": "X-PW-AccessKey"
-		        		},
-		        		"value": {
-		        			"type": "string",
-		        			"value": "123abc"
-		        		}
-		        	}
-		        }]
-		    }
+				value: [
+					{
+						'type': 'object',
+						'value': {
+							'name': {
+								'type': 'string',
+								'value': 'X-PW-AccessKey'
+							},
+							'value': {
+								'type': 'string',
+								'value': '123abc'
+							}
+						}
+					}
+				]
+			}
 		};
 
-		var globalModel = getGlobalModel({ model: sampleGlobalModel });
+		var globalModel = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 		assert.deepEqual(globalModel.options.headers['X-PW-AccessKey'], '123abc');
 	});
 
@@ -362,29 +378,32 @@ describe('#getGlobalModel', function () {
 			},
 			headers: {
 				type: 'array',
-				value: [{
-					type: 'object',
-					value: {
-						name: {
-							type: 'string',
-							value: ' '
-						},
+				value: [
+					{
+						type: 'object',
 						value: {
-							type: 'string',
-							value: '123abc'
+							name: {
+								type: 'string',
+								value: ' '
+							},
+							value: {
+								type: 'string',
+								value: '123abc'
+							}
 						}
 					}
-				}]
+				]
 			}
 		};
 
-		var model = getGlobalModel({ model: sampleGlobalModel });
+		var model = getGlobalModel({ name: 'global_model', model: sampleGlobalModel });
 		assert.strictEqual(model.options.headers[' '], undefined);
 	});
 
 
 	it('should return a function if the global model is a function', function () {
-		var model = getGlobalModel({ 
+		var model = getGlobalModel({
+			name: 'global_model',
 			model: {
 				type: 'function',
 				value: 'function (input) { return { success: true }; }'

--- a/test/parseConfig/getHelper.js
+++ b/test/parseConfig/getHelper.js
@@ -11,7 +11,7 @@ describe('#getHelper', function () {
 			value: 'function (foo) { return \'test\' + foo; }',
 		};
 
-		var helper = getHelper(data);
+		var helper = getHelper(data, 'test_helper');
 
 		assert(_.isFunction(helper));
 		assert(helper('chris'), 'testchris');

--- a/test/parseConfig/getModel.js
+++ b/test/parseConfig/getModel.js
@@ -9,104 +9,108 @@ describe('#getModel', function () {
 
 	beforeEach(function () {
 		sampleModel = {
-		    "type": "object",
-		    "value": {
-		      "afterFailure": {
-		        "type": "function",
-		        "value": "function () { }"
-		      },
-		      "afterSuccess": {
-		        "type": "function",
-		        "value": "function () { }"
-		      },
-		      "auth": {
-		        "type": "object",
-		        "value": {}
-		      },
-		      "url": {
-		        "type": "string",
-		        "value": "/tasks"
-		      },
-		      "before": {
-		        "type": "function",
-		        "value": "function () { }"
-		      },
-		      "data": {
-		        "type": "object",
-		        "value": {
-		        	"name": {
-		        		"type": "string",
-		        		"value": "Chris"
-		        	}
-		        }
-		      },
-		      "expects": {
-		        "type": "string",
-		        "value": "2xx"
-		      },
-		      "headers": {
-		        "type": "array",
-		        "value": [{
-		        	"type": "object",
-		        	"value": {
-		        		"name": {
-		        			"type": "string",
-		        			"value": "Content-Type"
-		        		},
-		        		"value": {
-		        			"type": "string",
-		        			"value": "application/json"
-		        		}
-		        	}
-		        }, 
-		        {
-		        	"type": "object",
-		        	"value": {
-		        		"name": {
-		        			"type": "string",
-		        			"value": "Content-Length"
-		        		},
-		        		"value": {
-		        			"type": "number",
-		        			"value": 252
-		        		}
-		        	}
-		        }]
-		      },
-		      "notExpects": {
-		        "type": "function",
-		        "value": "function (input) {}"
-		      },
-		      "query": {
-		        "type": "array",
-		        "value": [{
-		        	"type": "object",
-		        	"value": {
-		        		"key": {
-		        			"type": "string",
-		        			"value": "per_page"
-		        		},
-		        		"value": {
-		        			"type": "string",
-		        			"value": "100"
-		        		}
-		        	}
-		        }, 
-		        {
-		        	"type": "object",
-		        	"value": {
-		        		"key": {
-		        			"type": "string",
-		        			"value": "page"
-		        		},
-		        		"value": {
-		        			"type": "string",
-		        			"value": "1"
-		        		}
-		        	}
-		        }]
-		      }
-		    }
+			'type': 'object',
+			'value': {
+				'afterFailure': {
+					'type': 'function',
+					'value': 'function () { }'
+				},
+				'afterSuccess': {
+					'type': 'function',
+					'value': 'function () { }'
+				},
+				'auth': {
+					'type': 'object',
+					'value': {}
+				},
+				'url': {
+					'type': 'string',
+					'value': '/tasks'
+				},
+				'before': {
+					'type': 'function',
+					'value': 'function () { }'
+				},
+				'data': {
+					'type': 'object',
+					'value': {
+						'name': {
+							'type': 'string',
+							'value': 'Chris'
+						}
+					}
+				},
+				'expects': {
+					'type': 'string',
+					'value': '2xx'
+				},
+				'headers': {
+					'type': 'array',
+					'value': [
+						{
+							'type': 'object',
+							'value': {
+								'name': {
+									'type': 'string',
+									'value': 'Content-Type'
+								},
+								'value': {
+									'type': 'string',
+									'value': 'application/json'
+								}
+							}
+						},
+						{
+							'type': 'object',
+							'value': {
+								'name': {
+									'type': 'string',
+									'value': 'Content-Length'
+								},
+								'value': {
+									'type': 'number',
+									'value': 252
+								}
+							}
+						}
+					]
+				},
+				'notExpects': {
+					'type': 'function',
+					'value': 'function (input) {}'
+				},
+				'query': {
+					'type': 'array',
+					'value': [
+						{
+							'type': 'object',
+							'value': {
+								'key': {
+									'type': 'string',
+									'value': 'per_page'
+								},
+								'value': {
+									'type': 'string',
+									'value': '100'
+								}
+							}
+						},
+						{
+							'type': 'object',
+							'value': {
+								'key': {
+									'type': 'string',
+									'value': 'page'
+								},
+								'value': {
+									'type': 'string',
+									'value': '1'
+								}
+							}
+						}
+					]
+				}
+			}
 		};
 
 		// console.log(sampleModel)
@@ -114,28 +118,28 @@ describe('#getModel', function () {
 
 
 	it('should bind URL', function () {
-		var model = getModel({ model: sampleModel });
+		const model = getModel({ name: 'test_op', model: sampleModel });
 
 		assert.strictEqual(model.url, '/tasks');
 
 		sampleModel.value.url = {
 			type: 'function',
 			value: 'function (input) { return \'/tasks\'; }',
-		}
-		var model = getModel({ model: sampleModel });
-		assert(_.isFunction(model.url));
+		};
+		const model2 = getModel({ name: 'test_op2', model: sampleModel });
+		assert(_.isFunction(model2.url));
 	});
 
 
 	it('should bind expects and not expects', function () {
-		var model = getModel({ model: sampleModel });
+		var model = getModel({ name: 'test_op', model: sampleModel });
 		assert.strictEqual(model.expects, '2xx');
 		assert(_.isFunction(model.notExpects));
 	});
 
 
 	it('should bind the lifecycle methods', function () {
-		var model = getModel({ model: sampleModel });
+		var model = getModel({ name: 'test_op', model: sampleModel });
 
 		assert(_.isFunction(model.before));
 		assert(_.isFunction(model.afterSuccess));
@@ -144,69 +148,73 @@ describe('#getModel', function () {
 
 
 	it('should bind the query', function () {
-		var model = getModel({ model: sampleModel });
-		assert.deepEqual(model.query, { 
-			per_page: '100', 
-			page: '1' 
+		var model = getModel({ name: 'test_op', model: sampleModel });
+		assert.deepEqual(model.query, {
+			per_page: '100',
+			page: '1'
 		});
 	});
 
 	it('should not bind query params with no name', function () {
-		sampleModel.value.query.value = [{
-			"type": "object",
-			"value": {
-				"key": {
-					"type": "string",
-					"value": " "
-				},
-				"value": {
-					"type": "string",
-					"value": "application/json"
+		sampleModel.value.query.value = [
+			{
+				'type': 'object',
+				'value': {
+					'key': {
+						'type': 'string',
+						'value': ' '
+					},
+					'value': {
+						'type': 'string',
+						'value': 'application/json'
+					}
 				}
 			}
-		}];
+		];
 
-		var model = getModel({ model: sampleModel });
+		var model = getModel({ name: 'test_op', model: sampleModel });
 		assert.deepEqual(model.query, []);
 	});
 
 
 	it('should bind the headers', function () {
-		var model = getModel({ model: sampleModel });
-		assert.deepEqual(model.options.headers, { 
-			'Content-Type': 'application/json', 
+		var model = getModel({ name: 'test_op', model: sampleModel });
+		assert.deepEqual(model.options.headers, {
+			'Content-Type': 'application/json',
 			'Content-Length': 252
 		});
 	});
 
 	it('should not bind headers with no name', function () {
-		sampleModel.value.headers.value = [{
-			"type": "object",
-			"value": {
-				"name": {
-					"type": "string",
-					"value": " "
-				},
-				"value": {
-					"type": "string",
-					"value": "application/json"
+		sampleModel.value.headers.value = [
+			{
+				'type': 'object',
+				'value': {
+					'name': {
+						'type': 'string',
+						'value': ' '
+					},
+					'value': {
+						'type': 'string',
+						'value': 'application/json'
+					}
 				}
 			}
-		}];
+		];
 
-		var model = getModel({ model: sampleModel });
+		var model = getModel({ name: 'test_op', model: sampleModel });
 		assert.deepEqual(model.options.headers, { });
 	});
 
 	it('should bind the data', function () {
-		var model = getModel({ model: sampleModel });
-		assert.deepEqual(model.data, { 
+		var model = getModel({ name: 'test_op', model: sampleModel });
+		assert.deepEqual(model.data, {
 			name: 'Chris'
 		});
 	});
 
 	it('should return a function if the model is a function', function () {
-		var model = getModel({ 
+		var model = getModel({
 			model: {
 				type: 'function',
 				value: 'function (input) { return { success: true }; }'

--- a/test/parseConfig/normalizeModelParameter.js
+++ b/test/parseConfig/normalizeModelParameter.js
@@ -20,7 +20,7 @@ describe('#normalizeModelParameter', function () {
 			}
 		};
 
-		assert.deepEqual(normalize(data), {
+		assert.deepEqual(normalize(data, 'test_op'), {
 			name: 'Chris',
 			age: 27
 		});
@@ -47,7 +47,7 @@ describe('#normalizeModelParameter', function () {
 			}
 		};
 
-		assert.deepEqual(normalize(data), {
+		assert.deepEqual(normalize(data, 'test_op'), {
 			employees: {
 				adrien: false,
 				chris: true,
@@ -67,7 +67,7 @@ describe('#normalizeModelParameter', function () {
 			}
 		};
 
-		assert.deepEqual(normalize(data), {
+		assert.deepEqual(normalize(data, 'test_op'), {
 			employees: {}
 		});
 	});
@@ -79,55 +79,63 @@ describe('#normalizeModelParameter', function () {
 			value: {
 				users: {
 					type: 'array',
-					value: [{
-						type: 'object',
-						value: {
-							name: {
-								type: 'string',
-								value: 'Ali'
-							},
-							favorite_foods: {
-								type: 'array',
-								value: [{
+					value: [
+						{
+							type: 'object',
+							value: {
+								name: {
 									type: 'string',
-									value: 'Katsu Wrap'
-								}, {
+									value: 'Ali'
+								},
+								favorite_foods: {
+									type: 'array',
+									value: [
+										{
+											type: 'string',
+											value: 'Katsu Wrap'
+										}, {
+											type: 'string',
+											value: 'Byron Milkshake'
+										}
+									]
+								}
+							}
+						}, {
+							type: 'object',
+							value: {
+								name: {
 									type: 'string',
-									value: 'Byron Milkshake'
-								}]
+									value: 'Chris'
+								},
+								favorite_foods: {
+									type: 'array',
+									value: [
+										{
+											type: 'string',
+											value: 'Poppies'
+										}, {
+											type: 'string',
+											value: 'Japanika'
+										}
+									]
+								}
 							}
 						}
-					}, {
-						type: 'object',
-						value: {
-							name: {
-								type: 'string',
-								value: 'Chris'
-							},
-							favorite_foods: {
-								type: 'array',
-								value: [{
-									type: 'string',
-									value: 'Poppies'
-								}, {
-									type: 'string',
-									value: 'Japanika'
-								}]
-							}
-						}
-					}]
+					]
 				}
 			}
 		};
 
-		assert.deepEqual(normalize(data), {
-			users: [{
-				name: 'Ali',
-				favorite_foods: ['Katsu Wrap', 'Byron Milkshake']
-			}, {
-				name: 'Chris',
-				favorite_foods: ['Poppies', 'Japanika']
-			}]
+		assert.deepEqual(normalize(data, 'test_op'), {
+			users: [
+				{
+					name: 'Ali',
+					favorite_foods: [ 'Katsu Wrap', 'Byron Milkshake' ]
+				}, {
+					name: 'Chris',
+					favorite_foods: [ 'Poppies', 'Japanika' ]
+				}
+			]
 		});
 	});
 
@@ -138,7 +146,7 @@ describe('#normalizeModelParameter', function () {
 			value: 'function (input) { return { name: "Chris" }; }'
 		};
 
-		const fn = normalize(data);
+		const fn = normalize(data, 'test_op');
 
 		assert(_.isFunction(fn));
 		assert.deepEqual(fn(), { name: 'Chris' });
@@ -151,7 +159,7 @@ describe('#normalizeModelParameter', function () {
 			value: undefined
 		};
 
-		const fn = normalize(data);
+		const fn = normalize(data, 'test_op');
 
 		assert(_.isFunction(fn));
 		assert.deepEqual(fn({ test: true, age: 27 }), {});
@@ -172,7 +180,7 @@ describe('#normalizeModelParameter', function () {
 			}
 		};
 
-		const obj = normalize(data2);
+		const obj = normalize(data2, 'test_op');
 		assert(_.isObject(obj));
 		assert.deepEqual(obj, { age: 27 });
 	});

--- a/test/rawHttpRequest/formatOutput_test.js
+++ b/test/rawHttpRequest/formatOutput_test.js
@@ -1,0 +1,128 @@
+const assert = require('assert');
+const { PassThrough } = require('stream');
+
+const _ = require('lodash');
+
+const formatOutput = require('../../lib/rawHttpRequest/formatOutput.js');
+
+describe('formatOutput', () => {
+
+	it('should be a function', () => {
+		assert(_.isFunction(formatOutput));
+	});
+
+	it('should return in correct format', () => {
+
+		const sampleParams = {
+			body: {
+				raw: 'Hello world',
+			},
+			processedBody: 'Hello world',
+			headers: [
+				{
+					key: 'Authorization',
+					value: 'Bearer test'
+				}
+			]
+		};
+		const sampleResponse = {
+			statusCode: 200,
+			headers: {
+				'content-type': 'text/plain'
+			},
+			body: 'ok',
+			raw: 'ok',
+		};
+
+		const formattedOutput = formatOutput(sampleResponse.body, sampleParams, sampleResponse);
+
+		assert(_.isPlainObject(formattedOutput.response));
+		const { response } = formattedOutput;
+		assert.strictEqual(response.status_code, 200);
+		assert.deepEqual(
+			response.headers,
+			{
+				'content-type': 'text/plain'
+			}
+		);
+		assert.strictEqual(response.body, 'ok');
+	});
+
+	it('should include raw_body if include_raw_body is true', () => {
+
+		const sampleParams = {
+			body: {
+				raw: 'Hello world',
+			},
+			processedBody: 'Hello world',
+			headers: [
+				{
+					key: 'Authorization',
+					value: 'Bearer test'
+				}
+			],
+			include_raw_body: true
+		};
+		const sampleResponse = {
+			statusCode: 200,
+			headers: {
+				'content-type': 'text/plain'
+			},
+			body: 'ok',
+			raw: 'ok',
+		};
+
+		const formattedOutput = formatOutput(sampleResponse.body, sampleParams, sampleResponse);
+
+		assert(_.isPlainObject(formattedOutput.response));
+		const { response } = formattedOutput;
+		assert.strictEqual(response.status_code, 200);
+		assert.deepEqual(
+			response.headers,
+			{
+				'content-type': 'text/plain'
+			}
+		);
+		assert.strictEqual(response.body, 'ok');
+		assert.strictEqual(response.raw_body, 'ok');
+	});
+
+	it('should throw if body is too large', () => {
+
+		const sampleParams = {
+			body: {
+				raw: 'Hello world',
+			},
+			processedBody: 'Hello world',
+			headers: [
+				{
+					key: 'Authorization',
+					value: 'Bearer test'
+				}
+			]
+		};
+
+		let largeBody;
+		for (let count = 0; count < 1024; count++) {
+			largeBody += 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+		}
+
+		const sampleResponse = {
+			statusCode: 200,
+			headers: {
+				'content-type': 'text/plain'
+			},
+			body: largeBody,
+			raw: largeBody,
+		};
+
+		try {
+			const formattedOutput = formatOutput(sampleResponse.body, sampleParams, sampleResponse);
+			assert.fail(formattedOutput);
+		} catch (formatOutputError) {
+			assert.strictEqual(formatOutputError.message, 'The operation result is too large. Modify the request to return a smaller response. If `Include raw body` is enabled, consider disabling it.');
+			assert.strictEqual(formatOutputError.code, '#user_input_error');
+		}
+	});
+
+});

--- a/test/rawHttpRequest/processOptions_test.js
+++ b/test/rawHttpRequest/processOptions_test.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const fs = require('fs');
 const { PassThrough } = require('stream');
 
 const _ = require('lodash');


### PR DESCRIPTION
#150 CPS-205/CPB-211: Disable dev server via environment variable
#152 CPS-209/CPB-276: Raw HTTP Client - title update, schema updates, and URL configuration
#153 CPS-203/CPB-257: File handling updates (expiry time and check)
#154 CPS-220/CPB-267: Raw HTTP Client - status code and output bug fix
#156 CPS-215/CPB-239: File handling input validation
#159 CPB-247: `#no_trigger` code update
#155 and #161 CPS-126/CPB-219: DDL and private schema.js support 
#160 CPB-266: artisan error handling attempted improvements (for connector debugging)