### PR TITLE
CPB-219: DDL op names bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ module.exports = {
 };
 ```
 
-### Messages
+### Operations (previously Messages)
 
 On a high level, the following rules apply for each message.
 
@@ -140,6 +140,7 @@ module.exports = {
 This schema will be used to generate the `input_schema` for each message. Also, the
 `required` variable applies a validation before the operation executes at runtime.
 
+`type` is a top level schema.js property for which the allowed values are `public`, `ddl`, and `private`. If `type` is not provided, the `public` is assumed by default, unless the operation name ends with `_ddl`. Only `public` and `ddl` operation types are added to the connectors.json.
 
 ### Model
 

--- a/exampleTwo/connectors.json
+++ b/exampleTwo/connectors.json
@@ -122,6 +122,26 @@
 				"dynamic_output": false
 			},
 			{
+				"title": "Test op two DDL",
+				"type": "ddl",
+				"input_schema": {
+					"type": "object",
+					"properties": {
+						"domain": {
+							"type": "string",
+							"description": "Domain",
+							"title": "Domain"
+						}
+					},
+					"required": [
+						"domain"
+					],
+					"advanced": [],
+					"$schema": "http://json-schema.org/draft-04/schema#",
+					"additionalProperties": false
+				}
+			},
+			{
 				"name": "test_op",
 				"title": "Test operation",
 				"type": "public",

--- a/exampleTwo/connectors.json
+++ b/exampleTwo/connectors.json
@@ -123,6 +123,7 @@
 			},
 			{
 				"title": "Test op two DDL",
+				"name": "test_op_two_ddl",
 				"type": "ddl",
 				"input_schema": {
 					"type": "object",

--- a/exampleTwo/connectors/testconnector/test_op_two_ddl/model.js
+++ b/exampleTwo/connectors/testconnector/test_op_two_ddl/model.js
@@ -1,0 +1,10 @@
+module.exports = function (params) {
+	return {
+		results: [
+			{
+				text: 'hello',
+				value: 'world'
+			}
+		]
+	};
+};

--- a/exampleTwo/docs.html
+++ b/exampleTwo/docs.html
@@ -33,6 +33,15 @@
 		
 		<tr>
 			<td>
+				<em>Test op two DDL</em>
+			</td>
+			<td>
+				
+			</td>
+		</tr>
+		
+		<tr>
+			<td>
 				<em>Test operation</em>
 			</td>
 			<td>

--- a/lib/buildConnectorsJson/index.js
+++ b/lib/buildConnectorsJson/index.js
@@ -118,6 +118,7 @@ module.exports = function (directory, config) {
 				( operationType === 'public' ?  standardPick : ddlPick )
 			);
 
+			operationJson.name = operationJson.name || operationConfig.name;
 			operationJson.type = operationType;
 
 			// Generate the input

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0",
+  "version": "1.27.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.27.0",
+  "version": "1.27.0-alpha.1",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/buildConnectorsJson/index.js
+++ b/test/buildConnectorsJson/index.js
@@ -52,6 +52,62 @@ describe('#buildConnectorsJson', function () {
 
 	});
 
+	it('should have name for all operation variants', function () {
+		const outputJsonString = buildConnectorsJson(null, [
+			_.defaults(
+				{
+					messages: [
+						{
+							name: 'my_operation',
+							model: {
+								url: '..'
+							},
+							schema: {
+								input: {
+									name: {
+										type: 'string'
+									}
+								}
+							}
+						},
+						{
+							name: 'my_private_operation',
+							model: {
+								url: '..'
+							}
+						},
+						{
+							name: 'my_operation_ddl',
+							model: {
+								url: '..'
+							},
+							schema: {
+								type: 'ddl',
+								input: {
+									name: {
+										type: 'string'
+									}
+								}
+							}
+						},
+						{
+							name: 'my_operation_two_ddl',
+							model: {
+								url: '..'
+							}
+						}
+					]
+				},
+				exampleConfig
+			)
+		]);
+
+		assert.equal(outputJsonString[0].messages.length, 3);
+		assert.equal(outputJsonString[0].messages[0].name, 'my_operation');
+		assert.equal(outputJsonString[0].messages[1].name, 'my_operation_ddl');
+		assert.equal(outputJsonString[0].messages[2].name, 'my_operation_two_ddl');
+	});
+
 	it('should validate `branches` property', function () {
 
 		const inputConfig = _.cloneDeep(exampleConfig);
@@ -121,7 +177,7 @@ describe('#buildConnectorsJson', function () {
 
 	});
 
-	it('should not add operations without schemas', function () {
+	it('should not add private operations (non-ddl ops without schemas)', function () {
 
 		const outputJsonString = buildConnectorsJson(null, [
 			_.defaults(
@@ -482,6 +538,7 @@ describe('#buildConnectorsJson', function () {
 		]);
 
 		assert.equal(parsedJsonSchema[0].messages.length, 1);
+		assert.equal(parsedJsonSchema[0].messages[0].name, 'my_operation_ddl');
 		assert.equal(parsedJsonSchema[0].messages[0].type, 'ddl');
 		assert.deepEqual(
 			parsedJsonSchema[0].messages[0].input_schema,
@@ -836,6 +893,7 @@ describe('#buildConnectorsJson', function () {
 						icon: _.pick(inputConfig.icon, [ 'value', 'type' ]),
 						messages: [
 							{
+								name: 'my_operation',
 								title: 'My operation',
 								type: 'public',
 								input_schema: {


### PR DESCRIPTION
Fixed a bug where operation names were not being added to the connectors.json for DDLs without schema.js files.

Also updated readme