### PR TITLE
[CSP-6201] add acl to falafel s3 upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ The `falafel.files.streamUpload` accepts the following object:
     contentType: '[Mime type of file]', //optional (falafel will attempt to derive it from name if not provided)
 
     bucket: '[AWS bucket]', //optional target bucket
-    region: '[AWS region]' //optional target region
+    region: '[AWS region]',  //optional target region
+    disableObjectAcl: // optional flag to disable S3 object ACL for bucket-owner-full-control
 }
 ```
 
@@ -299,7 +300,8 @@ The `falafel.files.upload` accepts the following object:
     contentType: '[Mime type of file]', //optional (falafel will attempt to derive it from name if not provided)
 
     bucket: '[AWS bucket]', //optional target bucket
-    region: '[AWS region]' //optional target region
+    region: '[AWS region]', //optional target region
+    disableObjectAcl: // optional flag to disable S3 object ACL for bucket-owner-full-control
 }
 ```
 This function assumes the file is in local storage and will attempt to `createReadStream` from it; as such this is the least recommended upload option.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ Note: all signed URLs return an expiry time of 6 hours.
 
 `CONNECTOR_FILE_REGION` and `CONNECTOR_FILE_BUCKET` environment variables can be set to override the default region and bucket.
 
+Unless the `disableObjectAcl` flag is set, the upload functions will create the S3 object with the access control list (ACL) property of `bucket-owner-full-control`. This means the owning AWS account of the target bucket will have access to the object even if the upload is being run from a different account.
+
 #### `falafel.files.streamUpload` (recommended)
 The `falafel.files.streamUpload` accepts the following object:
 ```js

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -32,6 +32,8 @@ const availableRAM = ( ALLOCATED_RAM ? _.parseInt(ALLOCATED_RAM) : 128 ); //128M
 const UPLOAD_MIN_SIZE = 1024 * 1024 * 8, //8MB
 	MAX_RAM = 1024 * 1024 * availableRAM;
 
+const S3_OBJECT_ACL = 'bucket-owner-full-control';
+
 /*
 	128 / 16 = 8 (which is UPLOAD_MIN_SIZE)
 	TARGET_SIZE should either be 8MB (since default assumed RAM is 128MB) or
@@ -150,7 +152,7 @@ module.exports = function (options) {
 			const s3 = new AWS.S3({ region: params.region || REGION });
 
 			s3.upload(
-				uploadParams,
+				{ ...uploadParams, ACL: S3_OBJECT_ACL },
 				uploadOptions,
 				(fileUploadError, data) => {
 
@@ -215,7 +217,7 @@ module.exports = function (options) {
 				Bucket: params.bucket || TARGET_BUCKET,
 				Key: fileGuidName,
 				ContentType: mimeType,
-				ContentLength: params.length
+				ContentLength: params.length,
 			};
 
 			//Set relavant Body

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -32,7 +32,7 @@ const availableRAM = ( ALLOCATED_RAM ? _.parseInt(ALLOCATED_RAM) : 128 ); //128M
 const UPLOAD_MIN_SIZE = 1024 * 1024 * 8, //8MB
 	MAX_RAM = 1024 * 1024 * availableRAM;
 
-const S3_OBJECT_ACL = 'bucket-owner-full-control';
+const S3_OBJECT_FULL_CONTROL_ACL = 'bucket-owner-full-control';
 
 /*
 	128 / 16 = 8 (which is UPLOAD_MIN_SIZE)
@@ -148,11 +148,18 @@ module.exports = function (options) {
 	}
 
 	function s3Upload ({ params, fileGuidName, mimeType, uploadParams, uploadOptions = {} }) {
+
+		// set S3 object ACL so bucket owner can access even if uploader is different AWS account
+		const shouldSetObjectAcl = _.isUndefined(params.bucketOwnerFullControl) ? true : params.bucketOwnerFullControl;
+		if (shouldSetObjectAcl) {
+			uploadParams.ACL = S3_OBJECT_FULL_CONTROL_ACL;
+		}
+
 		return new Promise((resolve, reject) => {
 			const s3 = new AWS.S3({ region: params.region || REGION });
 
 			s3.upload(
-				{ ...uploadParams, ACL: S3_OBJECT_ACL },
+				uploadParams,
 				uploadOptions,
 				(fileUploadError, data) => {
 

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -150,7 +150,7 @@ module.exports = function (options) {
 	function s3Upload ({ params, fileGuidName, mimeType, uploadParams, uploadOptions = {} }) {
 
 		// set S3 object ACL so bucket owner can access even if uploader is different AWS account
-		const shouldSetObjectAcl = _.isBoolean(params.disableObjectAcl) ? params.disableObjectAcl : true;
+		const shouldSetObjectAcl = !(_.isBoolean(params.disableObjectAcl) && params.disableObjectAcl);
 		if (shouldSetObjectAcl) {
 			uploadParams.ACL = S3_OBJECT_FULL_CONTROL_ACL;
 		}

--- a/lib/fileHandler/index.js
+++ b/lib/fileHandler/index.js
@@ -150,7 +150,7 @@ module.exports = function (options) {
 	function s3Upload ({ params, fileGuidName, mimeType, uploadParams, uploadOptions = {} }) {
 
 		// set S3 object ACL so bucket owner can access even if uploader is different AWS account
-		const shouldSetObjectAcl = _.isUndefined(params.bucketOwnerFullControl) ? true : params.bucketOwnerFullControl;
+		const shouldSetObjectAcl = _.isBoolean(params.disableObjectAcl) ? params.disableObjectAcl : true;
 		if (shouldSetObjectAcl) {
 			uploadParams.ACL = S3_OBJECT_FULL_CONTROL_ACL;
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/falafel",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "A framework for developing and running connectors.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/parseConfig/getFunctionParameter.js
+++ b/test/parseConfig/getFunctionParameter.js
@@ -36,7 +36,7 @@ describe('#getFunctionParameter', function () {
 			fn({ sample: 'input' });
 		} catch (err) {
 			assert(_.isError(err));
-			assert.strictEqual(err.message, `Error occured for module 'test_op'. Error evaluating function 'before': Unexpected token {`);
+			assert.strictEqual(err.message, `Error occured for module 'test_op'. Error evaluating function 'before': Unexpected token '{'`);
 			didCatch = true;
 		}
 

--- a/test/parseConfig/getModel.js
+++ b/test/parseConfig/getModel.js
@@ -173,7 +173,7 @@ describe('#getModel', function () {
 		];
 
 		var model = getModel({ name: 'test_op', model: sampleModel });
-		assert.deepEqual(model.query, []);
+		assert.deepEqual(model.query, {});
 	});
 
 


### PR DESCRIPTION
This change resolves the following ticket: https://trayio.atlassian.net/browse/CSP-6201.

There is an issue with S3 objects not being accessible to connectors where the uploading connector was running under a different AWS account e.g. when using static IPs.

The cause is that an S3 object remains owned by the uploader and not by the bucket owner, meaning that any bucket level policies do not apply to that object. The solution is to add the `canned ACL` of `bucket-owner-full-control` to the S3 upload function.

This does require the permission of `PutObjectACL`, however both `connectors-upload` and `connector-vpc-s3` seem to have full access to the `workflow-file-uploads` bucket. I'm looking into other impact roles being updated, primarily it seems to be the freeman/customer related IAM roles e.g. `freeman-customer-customerName-us-west-1`.

This was tested in staging by copying the Falafel S3 upload function into the ftp-client and setting up routing for my staging user for the ftp-client to run in AWS account `e2e_staging`, and then access the uploaded file in CSV Reader running in the main account. 