### PR TITLE
[PSP-4983] Fix http method case

### DIFF
--- a/docs/pages/trigger_connectors.md
+++ b/docs/pages/trigger_connectors.md
@@ -127,6 +127,17 @@ module.exports = function (params, http) {
 };
 ```
 
+The following is the HTTP object provided:
+```JSON
+{
+	"http": "POST",
+	"headers": {
+		// key/string pairs of the incoming headers
+	},
+	"body": // the body from the incoming request. Parsed using JSON.parse if content-type is application/json
+}
+```
+
 **Note:** the HTTP verb provided is always upper case
 
 ### Adding a HTTP reply with `#no_trigger` error code

--- a/docs/pages/trigger_connectors.md
+++ b/docs/pages/trigger_connectors.md
@@ -127,6 +127,8 @@ module.exports = function (params, http) {
 };
 ```
 
+**Note:** the HTTP verb provided is always upper case
+
 ### Adding a HTTP reply with `#no_trigger` error code
 If a HTTP response needs to be specified along with the `#no_trigger` rejection code, the following format should be used:
 ```js

--- a/docs/pages/trigger_connectors.md
+++ b/docs/pages/trigger_connectors.md
@@ -117,7 +117,7 @@ If you'd like more fine grained control, declare it as a function returning a pr
 module.exports = function (params, http) {
   return when.promise(function (resolve, reject) {
 
-    if (http.method === 'post') {
+    if (http.method === 'POST') {
       resolve(http.body);
     } else {
       reject('#no_trigger');

--- a/example/connectors/pipedrive/webhook/request.js
+++ b/example/connectors/pipedrive/webhook/request.js
@@ -16,7 +16,7 @@
 // module.exports = function (params, http) {
 //   return when.promise(function (resolve, reject) {
 //
-//     if (http.method === 'post') {
+//     if (http.method === 'POST') {
 //       resolve(http.body);
 //     } else {
 //       reject('#trigger_ignore');


### PR DESCRIPTION
there are triggers that expect the method to be UPPER CASE, webhook is the exception as it converts the method to lower case before processing it. None expect the method to be lower case from the beginning